### PR TITLE
Build nightly extensions before 4.5 ones

### DIFF
--- a/factory-south-win7.bat
+++ b/factory-south-win7.bat
@@ -6,11 +6,11 @@ REM Nightly build of slicer vs2008 64bits
 REM Nightly build of slicer extensions testing vs2008 64bits
 "C:\D\Support\CMake 3.1.0-rc3\bin\ctest.exe" -S "C:\D\DashboardScripts\factory-south-win7-vs2008-64bits_slicerextensions_testing_release_nightly.cmake" -C Release -V -O C:\D\Logs\factory-south-win7-vs2008-64bits_slicerextensions_testing_release_nightly.txt
 
-REM Nightly build of slicer 4.5 extensions vs2008 64bits
-"C:\D\Support\CMake 3.0.1\bin\ctest.exe" -S "C:\D\DashboardScripts\factory-south-win7-vs2008-64bits_slicerextensions_45_release_nightly.cmake" -C Release -V -O C:\D\Logs\factory-south-win7-vs2008-64bits_slicerextensions_45_release_nightly.txt
-
 REM Nightly build of slicer extensions vs2008 64bits
 "C:\D\Support\CMake 3.1.0-rc3\bin\ctest.exe" -S "C:\D\DashboardScripts\factory-south-win7-vs2008-64bits_slicerextensions_release_nightly.cmake" -C Release -V -O C:\D\Logs\factory-south-win7-vs2008-64bits_slicerextensions_release_nightly.txt
+
+REM Nightly build of slicer 4.5 extensions vs2008 64bits
+"C:\D\Support\CMake 3.0.1\bin\ctest.exe" -S "C:\D\DashboardScripts\factory-south-win7-vs2008-64bits_slicerextensions_45_release_nightly.cmake" -C Release -V -O C:\D\Logs\factory-south-win7-vs2008-64bits_slicerextensions_45_release_nightly.txt
 
 :: Publish Slicer extension module metadata
 ::call C:\D\DashboardScripts\factory-south-win7-slicer-publish-extension-module-metadata.bat >C:\D\Logs\factory-south-win7-slicer-publish-extension-module-metadata.log 2>&1


### PR DESCRIPTION
As explained by @jcfr, with the current setup, all 4.5 extensions are built every
night, even when there are no updates to 4.5 extensions index. This prevents the
nightly extension, which are more likely to change, from being built at all.

Lacking automatic detection of the 4.5 extensions index changes and building of
the modified extensions only, it is proposed that the order between 4.5 and nightly
is changed manually on as needed basis. It is expected that nightly builds will be
changing at a faster pace than 4.5, thus it is natural to have nightly built in the
first place.