### PR TITLE
factory-south-macos/overload: Set FC env. variable to support building LAPACK

### DIFF
--- a/factory-south-macos-slicerextensions_preview_nightly.cmake
+++ b/factory-south-macos-slicerextensions_preview_nightly.cmake
@@ -51,6 +51,7 @@ set(ADDITIONAL_CMAKECACHE_OPTION "
 
 # Custom settings
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
+set(ENV{FC} "/Volumes/Dashboards/Support/miniconda3/envs/gfortran-env/bin/gfortran") # For LAPACKE
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #

--- a/factory-south-macos-slicerextensions_stable_nightly.cmake
+++ b/factory-south-macos-slicerextensions_stable_nightly.cmake
@@ -51,6 +51,7 @@ set(ADDITIONAL_CMAKECACHE_OPTION "
 
 # Custom settings
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
+set(ENV{FC} "/Volumes/Dashboards/Support/miniconda3/envs/gfortran-env/bin/gfortran") # For LAPACKE
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #

--- a/overload-vs2015-slicerextensions_preview_nightly.cmake
+++ b/overload-vs2015-slicerextensions_preview_nightly.cmake
@@ -52,6 +52,7 @@ set(ADDITIONAL_CMAKECACHE_OPTION "
 # Custom settings
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
 set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
+set(ENV{FC} "C:\\Miniconda3\\envs\\flang-env\\Library\\bin\\flang.exe") # For LAPACKE
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #

--- a/overload-vs2015-slicerextensions_stable_nightly.cmake
+++ b/overload-vs2015-slicerextensions_stable_nightly.cmake
@@ -52,6 +52,7 @@ set(ADDITIONAL_CMAKECACHE_OPTION "
 # Custom settings
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
 set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
+set(ENV{FC} "C:\\Miniconda3\\envs\\flang-env\\Library\\bin\\flang.exe") # For LAPACKE
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #


### PR DESCRIPTION
It is required by SPHARM-PDM [1] and GROUPS [2] extensions.

See https://github.com/Kitware/SlicerSALT/issues/125

[1] https://github.com/NIRALUser/SPHARM-PDM
[2] https://github.com/NIRALUser/GROUPS/tree/master/SuperBuild