### PR TITLE
metroplex: Update nightly builds to use Qt 5.15.0

### DIFF
--- a/metroplex-slicer_preview_nightly.cmake
+++ b/metroplex-slicer_preview_nightly.cmake
@@ -14,7 +14,7 @@ dashboard_set(Slicer_RELEASE_TYPE   "Preview")        # (E)xperimental, (P)revie
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
 dashboard_set(GIT_TAG               "master")         # Specify a tag for Stable release
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Ninja")
 dashboard_set(COMPILER              "g++-5.3.1")      # Used only to set the build name
@@ -29,7 +29,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.12.8")
+dashboard_set(QT_VERSION          "5.15.0")
 dashboard_set(Qt5_DIR             "$ENV{Qt5_DIR}")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/metroplex-slicer_preview_nightly.cmake
+++ b/metroplex-slicer_preview_nightly.cmake
@@ -14,7 +14,7 @@ dashboard_set(Slicer_RELEASE_TYPE   "Preview")        # (E)xperimental, (P)revie
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
 dashboard_set(GIT_TAG               "master")         # Specify a tag for Stable release
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Ninja")
 dashboard_set(COMPILER              "g++-5.3.1")      # Used only to set the build name
@@ -29,7 +29,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.11.2")
+dashboard_set(QT_VERSION          "5.12.8")
 dashboard_set(Qt5_DIR             "$ENV{Qt5_DIR}")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/metroplex-slicerextensions_preview_nightly.cmake
+++ b/metroplex-slicerextensions_preview_nightly.cmake
@@ -13,7 +13,7 @@ dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "Preview")        # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "master")       # "master", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "g++-5.3.1")      # Used only to set the build name
@@ -24,7 +24,7 @@ dashboard_set(CTEST_BUILD_FLAGS     "-j5 -l4")        # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.11.2")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.12.8")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build

--- a/metroplex-slicerextensions_preview_nightly.cmake
+++ b/metroplex-slicerextensions_preview_nightly.cmake
@@ -13,7 +13,7 @@ dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "Preview")        # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "master")       # "master", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "g++-5.3.1")      # Used only to set the build name
@@ -24,7 +24,7 @@ dashboard_set(CTEST_BUILD_FLAGS     "-j5 -l4")        # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.12.8")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.0")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build


### PR DESCRIPTION
**UPDATE: Read https://github.com/Slicer/DashboardScripts/pull/26#issuecomment-635027886**
 
--------------------------------
This PR updates the dashboard script for Metroplex to use Qt 5.12.8 and therefore requires 
- Metroplex be updated to Red Hat Enterprise Linux 7.4.

Qt 5.12.8 supports the below configuration ([source](https://doc-snapshots.qt.io/qt5-5.12/supported-platforms.html))

| Platform | Compiler | Notes |
|-----------|-----------|--------|
|Red Hat Enterprise Linux 7.4 (x86_64)| GCC 5.3.1 | devtoolset-4|

-------------------
Metroplex is currently running Red Hat Enterprise Linux 7.2 ([source](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Factory#metroplex.kitware)) and using Qt 5.11.2.
Qt 5.11.2 supports the below configuration ([source](https://doc.qt.io/archives/qt-5.11/supported-platforms-and-configurations.html))

| Platform | Compiler | Notes |
|-----------|-----------|--------|
|Red Hat Enterprise Linux 7.2 (x86_64)| GCC 5.3.1 | devtoolset-4|