### PR TITLE
factory-south-macos: Update nightly builds to use Qt 5.15.0

### DIFF
--- a/factory-south-macos-slicer_preview_nightly.cmake
+++ b/factory-south-macos-slicer_preview_nightly.cmake
@@ -17,7 +17,7 @@ if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "clang-11.0.3")    # Used only to set the build name
+dashboard_set(COMPILER              "clang-10.0.0")    # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")

--- a/factory-south-macos-slicer_preview_nightly.cmake
+++ b/factory-south-macos-slicer_preview_nightly.cmake
@@ -14,10 +14,10 @@ dashboard_set(Slicer_RELEASE_TYPE   "Preview")        # (E)xperimental, (P)revie
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
 dashboard_set(GIT_TAG               "master")         # Specify a tag for Stable release
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "clang-9.0.0")    # Used only to set the build name
+dashboard_set(COMPILER              "clang-11.0.3")    # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
@@ -29,7 +29,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.12.8")
+dashboard_set(QT_VERSION          "5.15.0")
 dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/qt-everywhere-build-${QT_VERSION}/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/factory-south-macos-slicer_preview_nightly.cmake
+++ b/factory-south-macos-slicer_preview_nightly.cmake
@@ -14,10 +14,10 @@ dashboard_set(Slicer_RELEASE_TYPE   "Preview")        # (E)xperimental, (P)revie
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
 dashboard_set(GIT_TAG               "master")         # Specify a tag for Stable release
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "clang-8.0.0")    # Used only to set the build name
+dashboard_set(COMPILER              "clang-9.0.0")    # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
@@ -29,7 +29,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.10.0")
+dashboard_set(QT_VERSION          "5.12.8")
 dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/qt-everywhere-build-${QT_VERSION}/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/factory-south-macos-slicerextensions_preview_nightly.cmake
+++ b/factory-south-macos-slicerextensions_preview_nightly.cmake
@@ -16,7 +16,7 @@ if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "clang-11.0.3")    # Used only to set the build name
+dashboard_set(COMPILER              "clang-10.0.0")    # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")

--- a/factory-south-macos-slicerextensions_preview_nightly.cmake
+++ b/factory-south-macos-slicerextensions_preview_nightly.cmake
@@ -13,10 +13,10 @@ dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "Preview")        # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "master")       # "master", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "clang-8.0.0")    # Used only to set the build name
+dashboard_set(COMPILER              "clang-9.0.0")    # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
@@ -24,7 +24,7 @@ dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.10.0")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.12.8")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build

--- a/factory-south-macos-slicerextensions_preview_nightly.cmake
+++ b/factory-south-macos-slicerextensions_preview_nightly.cmake
@@ -13,10 +13,10 @@ dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "Preview")        # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "master")       # "master", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "clang-9.0.0")    # Used only to set the build name
+dashboard_set(COMPILER              "clang-11.0.3")    # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
@@ -24,7 +24,7 @@ dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.12.8")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.0")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build


### PR DESCRIPTION
**UPDATE: Read https://github.com/Slicer/DashboardScripts/pull/27#issuecomment-635024624**
 
--------------------------------
This PR updates the dashboard script for Metroplex to use Qt 5.12.8. This PR is starting out as a draft since it is unclear how the stable builds of slicer and its extensions will continue to be built when the macOS build machine updates. Some updates required as part of building Qt 5.12.8 from source (accomplished by https://github.com/jcfr/qt-easy-build/pull/55)
Some potential options:
- Factory-south-macos be updated to macOS 10.13.6 (latest macOS High Sierra version)
- Xcode 9.4.1 installed (macOS 10.13 High Sierra SDK) Apple LLVM version 9.1.0 (clang-902.0.39.2)

- Factory-south-macos be updated to macOS 10.14.6 (latest macOS Mojave version)
- Xcode 10.3 installed (macOS 10.14 Mojave SDK) Apple LLVM version 10.0.1 (clang-1001.0.46.4)

- Slicer minimum deployment target updated to 10.12

Qt 5.12.8 supports the below configuration ([source](https://doc-snapshots.qt.io/qt5-5.12/supported-platforms.html))

| Platform | Architecture | Build Environment |
|-----------|-----------|--------|
|macOS 10.12, 10.13, 10.14| x86_64 and x86_64h | Xcode 10 (10.14 SDK), Xcode 9 (10.13 SDK)|

-------------------
Factory-south-macos is currently Mac OS X 10.11.6, El Capitan ([source](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Factory#factory-south.kitware)) and using Qt 5.10.0.
Qt 5.10.0 supports the below configuration ([source](https://doc.qt.io/archives/qt-5.10/supported-platforms-and-configurations.html))

| Platform | Compiler | Notes |
|-----------|-----------|--------|
| macOS 10.11, 10.12, 10.13 (x86_64) | Clang as provided by Apple | Xcode 8.2 (macOS 10.11), Xcode 8.3.3 (macOS 10.12), Xcode 9 (macOS 10.13)|