### PR TITLE
overload: Update nightly builds to use Qt 5.15.0

### DIFF
--- a/overload-vs2019-slicer_preview_nightly.cmake
+++ b/overload-vs2019-slicer_preview_nightly.cmake
@@ -5,63 +5,62 @@ macro(dashboard_set var value)
   endif()
 endmacro()
 
-dashboard_set(DASHBOARDS_DIR        "D:/D")
+dashboard_set(DASHBOARDS_DIR        "D:/D/")
 dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
 dashboard_set(HOSTNAME              "overload")
 dashboard_set(OPERATING_SYSTEM      "Windows10")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "P")              # (E)xperimental, (P)review or (S)table
-dashboard_set(EXTENSIONS_INDEX_BRANCH "master")       # "master", X.Y, ...
+dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
+dashboard_set(GIT_TAG               "master")         # Specify a tag for Stable release
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 16 2019")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
-dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v141")
-dashboard_set(COMPILER              "VS2017")         # Used only to set the build name
+dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v142")
+dashboard_set(COMPILER              "VS2019")         # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
 #dashboard_set(CMAKE_CXX_COMPILER    "/path/to/cxx/compiler")
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
-dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
+dashboard_set(WITH_MEMCHECK       FALSE)
+dashboard_set(WITH_COVERAGE       FALSE)
+dashboard_set(WITH_DOCUMENTATION  FALSE)
+dashboard_set(Slicer_BUILD_CLI    ON)
+dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION            "5.14.2")         # Used only to set the build name
+dashboard_set(QT_VERSION          "5.15.0")
+dashboard_set(Qt5_DIR             "D:/Support/Qt2/${QT_VERSION}/msvc2019_64/lib/cmake/Qt5")
 
-#   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
-#   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
+#   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
+#   Build directory  : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
 dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
-dashboard_set(Slicer_SOURCE_DIR "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}")
-dashboard_set(Slicer_DIR        "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}-build/Slicer-build")
 
-# CTEST_SOURCE_DIRECTORY: <Slicer_SOURCE_DIR>/Extensions/CMake
-# CTEST_BINARY_DIRECTORY: <DASHBOARDS_DIR>/<EXTENSION_DASHBOARD_SUBDIR>/<EXTENSION_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-E[-T]-b
-dashboard_set(EXTENSION_DASHBOARD_SUBDIR   "${Slicer_RELEASE_TYPE}")
-dashboard_set(EXTENSION_DIRECTORY_BASENAME "S")
-
-dashboard_set(EXTENSIONS_INDEX_GIT_TAG        "origin/${EXTENSIONS_INDEX_BRANCH}") # origin/master, origin/X.Y, ...
-dashboard_set(EXTENSIONS_INDEX_GIT_REPOSITORY "git://github.com/Slicer/ExtensionsIndex.git")
-
-# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
+# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoConsole][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
 set(BUILD_NAME_SUFFIX "")
 
+set(TEST_TO_EXCLUDE_REGEX "")
+
 set(ADDITIONAL_CMAKECACHE_OPTION "
+ADDITIONAL_C_FLAGS:STRING=/MP4
+ADDITIONAL_CXX_FLAGS:STRING=/MP4
 ")
 
 # Custom settings
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
 set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
-set(ENV{FC} "C:\\Miniconda3\\envs\\flang-env\\Library\\bin\\flang.exe") # For LAPACKE
+set(CTEST_SVN_COMMAND "C:/SlikSvn/bin/svn.exe")
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #
 ##########################################
-set(EXTENSIONS_TRACK_QUALIFIER ${EXTENSIONS_INDEX_BRANCH})
 if(NOT DEFINED DRIVER_SCRIPT)
-  set(url https://raw.githubusercontent.com/Slicer/Slicer/master/Extensions/CMake/SlicerExtensionsDashboardDriverScript.cmake)
+  set(url https://raw.githubusercontent.com/Slicer/Slicer/master/CMake/SlicerDashboardDriverScript.cmake)
   set(dest ${DASHBOARDS_DIR}/${EXTENSION_DASHBOARD_SUBDIR}/${CTEST_SCRIPT_NAME}.driver)
   file(DOWNLOAD ${url} ${dest} STATUS status)
   if(NOT status MATCHES "0.*")

--- a/overload-vs2019-slicerextensions_preview_nightly.cmake
+++ b/overload-vs2019-slicerextensions_preview_nightly.cmake
@@ -5,62 +5,63 @@ macro(dashboard_set var value)
   endif()
 endmacro()
 
-dashboard_set(DASHBOARDS_DIR        "D:/D/")
+dashboard_set(DASHBOARDS_DIR        "D:/D")
 dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
 dashboard_set(HOSTNAME              "overload")
 dashboard_set(OPERATING_SYSTEM      "Windows10")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "P")              # (E)xperimental, (P)review or (S)table
-dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
-dashboard_set(GIT_TAG               "master")         # Specify a tag for Stable release
+dashboard_set(EXTENSIONS_INDEX_BRANCH "master")       # "master", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 16 2019")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
-dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v141")
-dashboard_set(COMPILER              "VS2017")         # Used only to set the build name
+dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v142")
+dashboard_set(COMPILER              "VS2019")         # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
 #dashboard_set(CMAKE_CXX_COMPILER    "/path/to/cxx/compiler")
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
-dashboard_set(WITH_MEMCHECK       FALSE)
-dashboard_set(WITH_COVERAGE       FALSE)
-dashboard_set(WITH_DOCUMENTATION  FALSE)
-dashboard_set(Slicer_BUILD_CLI    ON)
-dashboard_set(Slicer_USE_PYTHONQT ON)
+dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION          "5.14.2")
-dashboard_set(Qt5_DIR             "D:/Support/Qt2/${QT_VERSION}/msvc2017_64/lib/cmake/Qt5")
+dashboard_set(QT_VERSION            "5.15.0")         # Used only to set the build name
 
-#   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
-#   Build directory  : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
+#   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
+#   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
 dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
+dashboard_set(Slicer_SOURCE_DIR "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}")
+dashboard_set(Slicer_DIR        "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}-build/Slicer-build")
 
-# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoConsole][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
+# CTEST_SOURCE_DIRECTORY: <Slicer_SOURCE_DIR>/Extensions/CMake
+# CTEST_BINARY_DIRECTORY: <DASHBOARDS_DIR>/<EXTENSION_DASHBOARD_SUBDIR>/<EXTENSION_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-E[-T]-b
+dashboard_set(EXTENSION_DASHBOARD_SUBDIR   "${Slicer_RELEASE_TYPE}")
+dashboard_set(EXTENSION_DIRECTORY_BASENAME "S")
+
+dashboard_set(EXTENSIONS_INDEX_GIT_TAG        "origin/${EXTENSIONS_INDEX_BRANCH}") # origin/master, origin/X.Y, ...
+dashboard_set(EXTENSIONS_INDEX_GIT_REPOSITORY "git://github.com/Slicer/ExtensionsIndex.git")
+
+# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
 set(BUILD_NAME_SUFFIX "")
 
-set(TEST_TO_EXCLUDE_REGEX "")
-
 set(ADDITIONAL_CMAKECACHE_OPTION "
-ADDITIONAL_C_FLAGS:STRING=/MP4
-ADDITIONAL_CXX_FLAGS:STRING=/MP4
 ")
 
 # Custom settings
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
 set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
-set(CTEST_SVN_COMMAND "C:/SlikSvn/bin/svn.exe")
+set(ENV{FC} "C:\\Miniconda3\\envs\\flang-env\\Library\\bin\\flang.exe") # For LAPACKE
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #
 ##########################################
+set(EXTENSIONS_TRACK_QUALIFIER ${EXTENSIONS_INDEX_BRANCH})
 if(NOT DEFINED DRIVER_SCRIPT)
-  set(url https://raw.githubusercontent.com/Slicer/Slicer/master/CMake/SlicerDashboardDriverScript.cmake)
+  set(url https://raw.githubusercontent.com/Slicer/Slicer/master/Extensions/CMake/SlicerExtensionsDashboardDriverScript.cmake)
   set(dest ${DASHBOARDS_DIR}/${EXTENSION_DASHBOARD_SUBDIR}/${CTEST_SCRIPT_NAME}.driver)
   file(DOWNLOAD ${url} ${dest} STATUS status)
   if(NOT status MATCHES "0.*")

--- a/overload.bat
+++ b/overload.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 
-:: CMAKE_VERSION=3.15.1 - This comment is used by the maintenance script to look up the cmake version
+:: CMAKE_VERSION=3.17.2 - This comment is used by the maintenance script to look up the cmake version
 
 :: To facilitate execution of the command below by copy/paste, they do not include variables.
 
@@ -34,7 +34,7 @@ call :fastdel "C:\Users\dashboard\AppData\Roaming\NA-MIC"
 :: ----------------------------------------------------------------------------
 ::echo "Slicer 'Preview' release"
 call :fastdel "D:\D\P\Slicer-0-build"
-"C:\cmake-3.15.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2017-slicer_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2017-slicer_preview_nightly.txt
+"C:\cmake-3.17.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicer_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2017-slicer_preview_nightly.txt
 
 :: ----------------------------------------------------------------------------
 :: Build Slicer Extensions
@@ -78,7 +78,7 @@ EXIT /B %ERRORLEVEL%
 :: ----------------------------------------------------------------------------
 :slicerextensions_preview_nightly
 ::echo "Slicer 'Preview' release extensions"
-"C:\cmake-3.15.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_preview_nightly.txt
+"C:\cmake-3.17.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_preview_nightly.txt
 EXIT /B 0
 
 :: ----------------------------------------------------------------------------

--- a/overload.bat
+++ b/overload.bat
@@ -78,7 +78,7 @@ EXIT /B %ERRORLEVEL%
 :: ----------------------------------------------------------------------------
 :slicerextensions_preview_nightly
 ::echo "Slicer 'Preview' release extensions"
-"C:\cmake-3.15.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2017-slicerextensions_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2015-slicerextensions_preview_nightly.txt
+"C:\cmake-3.15.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_preview_nightly.txt
 EXIT /B 0
 
 :: ----------------------------------------------------------------------------


### PR DESCRIPTION
This updates the Windows nightly builds to use Qt 5.15.0 which is also using the v142 (VS 2019) toolkit.  I had a successful build without errors which requires the VTK backport https://github.com/Slicer/VTK/pull/26 to be merged and then I'll need the Slicer superbuild updated to use the new Slicer/VTK git hash.  My successful build was with CMake 3.17.2, Visual Studio 2019 16.5.4, Windows 10 1909.
![image](https://user-images.githubusercontent.com/15837524/83020850-1bc73500-9ff7-11ea-8474-a8d1eb3df4e4.png)


A quote from the Qt [blog post](https://www.qt.io/blog/qt-5.15-released) about the 5.15 release

> A large amount of work has gone into bug fixes, and Qt 5.15 is the best and **most stable release we've done in the Qt 5 series.** 

There are of course more build warnings with Qt 5.15.0 as more things have been marked deprecated. This was done by Qt to make the transition to Qt 6 easier as Qt 5.15 is the last minor release version for Qt 5.  These can be fixed in time, but shouldn't introduce any problems.

Building with the v142 toolkit should be fine as any additional components that are binaries built with v140 (2015) or v141 (2017) will be ABI compatible. See https://docs.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=vs-2019.

cc: @sjh26 

- [x] Install Qt5.15 on overload

- [x] Install CMake 3.17.2 on overload

- [ ] Test build on overload