### PR TITLE
Generate script with dashboard

### DIFF
--- a/metroplex-slicer_preview_nightly.cmake
+++ b/metroplex-slicer_preview_nightly.cmake
@@ -29,7 +29,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.12.8")
+dashboard_set(QT_VERSION          "5.11.2")
 dashboard_set(Qt5_DIR             "$ENV{Qt5_DIR}")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/metroplex-slicerextensions_preview_nightly.cmake
+++ b/metroplex-slicerextensions_preview_nightly.cmake
@@ -24,7 +24,7 @@ dashboard_set(CTEST_BUILD_FLAGS     "-j5 -l4")        # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.12.8")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.11.2")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build


### PR DESCRIPTION
This PR adds generation of the build script to the dashboard for both Slicer Preview and SlicerSALT.  This includes rolling back to Qt 5.11.2