### PR TITLE
overload: Fix cell-locator build updating CMake version from 3.12.2 to 3.14.3

### DIFF
--- a/overload-vs2015-cell-locator_preview_experimental.bat
+++ b/overload-vs2015-cell-locator_preview_experimental.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-:: CMAKE_VERSION=3.12.2 - This comment is used by the maintenance script to look up the cmake version
+:: CMAKE_VERSION=3.14.3 - This comment is used by the maintenance script to look up the cmake version
 
 :: Disable tests
 set run_ctest_with_test=FALSE
@@ -8,7 +8,7 @@ set run_ctest_with_test=FALSE
 :: Build CellLocator
 :: ----------------------------------------------------------------------------
 ::echo "CellLocator 'Preview' release"
-"C:\cmake-3.12.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2015-cell-locator_preview_experimental.cmake" -C Release -VV -O D:\D\Logs\overload-vs2015-cell-locator_preview_experimental.txt
+"C:\cmake-3.14.3\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2015-cell-locator_preview_experimental.cmake" -C Release -VV -O D:\D\Logs\overload-vs2015-cell-locator_preview_experimental.txt
 
 ::echo "CellLocator 'Preview' release - generate package"
-"C:\cmake-3.12.2\bin\cmake.exe" --build "D:\D\P\CL-0-build/Slicer-build" --target PACKAGE --config Release > D:\D\Logs\overload-vs2015-cell-locator_preview_experimental-generate-package.txt 2>&1
+"C:\cmake-3.14.3\bin\cmake.exe" --build "D:\D\P\CL-0-build/Slicer-build" --target PACKAGE --config Release > D:\D\Logs\overload-vs2015-cell-locator_preview_experimental-generate-package.txt 2>&1


### PR DESCRIPTION
This required to support using the newer generator "Visual Studio 16 2019"
See https://cmake.org/cmake/help/latest/release/3.14.html#new-features