### PR TITLE
Update nightly builds for factory-macos-south to use Qt 5.15.1

### DIFF
--- a/factory-south-macos-slicer_preview_nightly.cmake
+++ b/factory-south-macos-slicer_preview_nightly.cmake
@@ -29,7 +29,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.15.0")
+dashboard_set(QT_VERSION          "5.15.1")
 dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/qt-everywhere-build-${QT_VERSION}/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/factory-south-macos-slicerextensions_preview_nightly.cmake
+++ b/factory-south-macos-slicerextensions_preview_nightly.cmake
@@ -24,7 +24,7 @@ dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.15.0")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.1")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build

--- a/factory-south-macos-slicersalt_300_release_package.cmake
+++ b/factory-south-macos-slicersalt_300_release_package.cmake
@@ -29,7 +29,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.15.0")
+dashboard_set(QT_VERSION          "5.15.1")
 dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/qt-everywhere-build-${QT_VERSION}/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/factory-south-macos-slicersalt_preview_nightly.cmake
+++ b/factory-south-macos-slicersalt_preview_nightly.cmake
@@ -29,7 +29,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.15.0")
+dashboard_set(QT_VERSION          "5.15.1")
 dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/qt-everywhere-build-${QT_VERSION}/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>


### PR DESCRIPTION
Qt 5.15.1 was [released](https://www.qt.io/blog/qt-5.15.1-released) on September 10th.  The qt-easy-build project was updated with a [5.15.1](https://github.com/jcfr/qt-easy-build/tree/5.15.1) branch and Azure pipelines CI is currently running the update.

Primary motivation for updating to use Qt 5.15.1 is that this closes https://github.com/Slicer/Slicer/issues/5106 in the factory-built Slicer nightly packages.  Currently building Slicer with Qt 5.15.1 to confirm this bug fix.