### PR TITLE
Update nightly builds for metroxplex and overload to use Qt 5.15.1 

### DIFF
--- a/metroplex-cell-locator_preview_experimental.cmake
+++ b/metroplex-cell-locator_preview_experimental.cmake
@@ -29,7 +29,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.11.2")
+dashboard_set(QT_VERSION          "5.15.1")
 dashboard_set(Qt5_DIR             "$ENV{Qt5_DIR}")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/metroplex-slicer_preview_nightly.cmake
+++ b/metroplex-slicer_preview_nightly.cmake
@@ -29,7 +29,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.11.2")
+dashboard_set(QT_VERSION          "5.15.1")
 dashboard_set(Qt5_DIR             "$ENV{Qt5_DIR}")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/metroplex-slicerextensions_preview_nightly.cmake
+++ b/metroplex-slicerextensions_preview_nightly.cmake
@@ -24,7 +24,7 @@ dashboard_set(CTEST_BUILD_FLAGS     "-j5 -l4")        # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.11.2")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.1")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build

--- a/metroplex.sh
+++ b/metroplex.sh
@@ -30,7 +30,7 @@ cd  /home/kitware/Dashboards/Slicer
 
 # Download and patch the slicer-buildenv-qt5-centos7-slicer-4.11-2018.10.17 image
 SLICER_PREVIEW_ENV_NAME=qt5-centos7
-SLICER_PREVIEW_ENV_VERSION=slicer-4.11-2018.10.17
+SLICER_PREVIEW_ENV_VERSION=latest
 
 # Download build environment
 slicer_preview_script=/home/kitware/bin/slicer-buildenv-${SLICER_PREVIEW_ENV_NAME}-${SLICER_PREVIEW_ENV_VERSION}

--- a/overload-vs2019-cell-locator_preview_experimental.cmake
+++ b/overload-vs2019-cell-locator_preview_experimental.cmake
@@ -31,7 +31,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.15.0")
+dashboard_set(QT_VERSION          "5.15.1")
 dashboard_set(Qt5_DIR             "D:/Support/Qt2/${QT_VERSION}/msvc2019_64/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/overload-vs2019-slicer_preview_nightly.cmake
+++ b/overload-vs2019-slicer_preview_nightly.cmake
@@ -31,7 +31,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.15.0")
+dashboard_set(QT_VERSION          "5.15.1")
 dashboard_set(Qt5_DIR             "D:/Support/Qt2/${QT_VERSION}/msvc2019_64/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/overload-vs2019-slicerextensions_preview_nightly.cmake
+++ b/overload-vs2019-slicerextensions_preview_nightly.cmake
@@ -26,7 +26,7 @@ dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.15.0")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.1")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build


### PR DESCRIPTION
See  https://github.com/Slicer/DashboardScripts/pull/31