### PR TITLE
ENH: Add snapshot release scripts for 4.11.20200930

### DIFF
--- a/factory-south-macos-slicer_4102_release_package.sh
+++ b/factory-south-macos-slicer_4102_release_package.sh
@@ -1,7 +1,0 @@
-# CMAKE_VERSION=NA - This comment is used by the maintenance script to look up the cmake version
-
-# Slicer 'Stable' release
-/Volumes/D/Support/CMake-3.12.2.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicer_4102_release_package.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicer_4102_release_package.log
-
-# Slicer 'Stable' release extensions
-/Volumes/D/Support/CMake-3.12.2.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicerextensions_stable_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicerextensions_stable_nightly.log

--- a/factory-south-macos-slicer_41120200930_release_package.cmake
+++ b/factory-south-macos-slicer_41120200930_release_package.cmake
@@ -5,23 +5,20 @@ macro(dashboard_set var value)
   endif()
 endmacro()
 
-dashboard_set(DASHBOARDS_DIR        "D:/D/")
+dashboard_set(DASHBOARDS_DIR        "/Volumes/D")
 dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
-dashboard_set(HOSTNAME              "overload")
-dashboard_set(OPERATING_SYSTEM      "Windows7")
+dashboard_set(HOSTNAME              "factory-south-macos")
+dashboard_set(OPERATING_SYSTEM      "macOS")
 dashboard_set(SCRIPT_MODE           "Experimental")   # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
-dashboard_set(SVN_REVISION          "28257")          # Specify a revision for Stable release
-dashboard_set(SVN_BRANCH            "branches/Slicer-4-10")
+dashboard_set(GIT_TAG               "v4.11.20200930") # Specify a tag for Stable release
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
-dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 16 2019")
-dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
-dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v140")
-dashboard_set(COMPILER              "VS2015")         # Used only to set the build name
-dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
+dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+dashboard_set(COMPILER              "clang-10.0.0")    # Used only to set the build name
+dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
 #dashboard_set(CMAKE_CXX_COMPILER    "/path/to/cxx/compiler")
@@ -32,36 +29,33 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.10.1")
-dashboard_set(Qt5_DIR             "D:/Support/Qt/${QT_VERSION}/msvc2015_64/lib/cmake/Qt5")
+dashboard_set(QT_VERSION          "5.15.1")
+dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/qt-everywhere-build-${QT_VERSION}/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Build directory  : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
-dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
+dashboard_set(Slicer_DIRECTORY_BASENAME   "S")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "4102")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
+# 0: 41120200930
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 
-# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoConsole][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
+# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
 set(BUILD_NAME_SUFFIX "")
 
 set(TEST_TO_EXCLUDE_REGEX "")
 
 set(ADDITIONAL_CMAKECACHE_OPTION "
-ADDITIONAL_C_FLAGS:STRING=/MP4
-ADDITIONAL_CXX_FLAGS:STRING=/MP4
 ")
 
 # Custom settings
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
-set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
-set(CTEST_SVN_COMMAND "C:/SlikSvn/bin/svn.exe")
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #
 ##########################################
 if(NOT DEFINED DRIVER_SCRIPT)
-  set(url http://svn.slicer.org/Slicer4/trunk/CMake/SlicerDashboardDriverScript.cmake)
+  set(url https://raw.githubusercontent.com/Slicer/Slicer/master/CMake/SlicerDashboardDriverScript.cmake)
   set(dest ${DASHBOARDS_DIR}/${EXTENSION_DASHBOARD_SUBDIR}/${CTEST_SCRIPT_NAME}.driver)
   file(DOWNLOAD ${url} ${dest} STATUS status)
   if(NOT status MATCHES "0.*")
@@ -70,3 +64,4 @@ if(NOT DEFINED DRIVER_SCRIPT)
   set(DRIVER_SCRIPT ${dest})
 endif()
 include(${DRIVER_SCRIPT})
+

--- a/factory-south-macos-slicer_41120200930_release_package.sh
+++ b/factory-south-macos-slicer_41120200930_release_package.sh
@@ -1,0 +1,7 @@
+# CMAKE_VERSION=NA - This comment is used by the maintenance script to look up the cmake version
+
+# Slicer 'Stable' release
+/Volumes/D/Support/CMake-3.15.1.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicer_41120200930_release_package.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicer_41120200930_release_package.log
+
+# Slicer 'Stable' release extensions
+/Volumes/D/Support/CMake-3.15.1.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicerextensions_stable_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicerextensions_stable_nightly.log

--- a/factory-south-macos-slicerextensions_stable_nightly.cmake
+++ b/factory-south-macos-slicerextensions_stable_nightly.cmake
@@ -11,12 +11,12 @@ dashboard_set(HOSTNAME              "factory-south-macos")
 dashboard_set(OPERATING_SYSTEM      "macOS")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
-dashboard_set(EXTENSIONS_INDEX_BRANCH "4.10")          # "master", X.Y, ...
+dashboard_set(EXTENSIONS_INDEX_BRANCH "4.11")          # "master", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "clang-8.0.0")    # Used only to set the build name
+dashboard_set(COMPILER              "clang-10.0.0")    # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
@@ -24,13 +24,14 @@ dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.10.0")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.1")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "S")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "4102")      # Set to arbitrary integer to distinguish different Experimental/Preview release build
+#0: 41120200930
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")      # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 dashboard_set(Slicer_SOURCE_DIR "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}")
 dashboard_set(Slicer_DIR        "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}-build/Slicer-build")

--- a/metroplex-slicer_41120200930_release_package.cmake
+++ b/metroplex-slicer_41120200930_release_package.cmake
@@ -12,10 +12,9 @@ dashboard_set(OPERATING_SYSTEM      "Linux")
 dashboard_set(SCRIPT_MODE           "Experimental")   # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "Stable")         # (E)xperimental, (P)review or (S)table
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
-dashboard_set(SVN_REVISION          "28257")          # Specify a revision for Stable release
-dashboard_set(SVN_BRANCH            "branches/Slicer-4-10")
+dashboard_set(GIT_TAG               "v4.11.20200930") # Specify a tag for Stable release
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Ninja")
 dashboard_set(COMPILER              "g++-5.3.1")      # Used only to set the build name
@@ -30,14 +29,15 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.11.2")
+dashboard_set(QT_VERSION          "5.15.1")
 dashboard_set(Qt5_DIR             "$ENV{Qt5_DIR}")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Build directory  : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "4102")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
+# 0: 41120200930
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 
 # Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
@@ -58,7 +58,7 @@ include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
 # WARNING: DO NOT EDIT BEYOND THIS POINT #
 ##########################################
 if(NOT DEFINED DRIVER_SCRIPT)
-  set(url http://svn.slicer.org/Slicer4/trunk/CMake/SlicerDashboardDriverScript.cmake)
+  set(url https://raw.githubusercontent.com/Slicer/Slicer/master/CMake/SlicerDashboardDriverScript.cmake)
   set(dest ${DASHBOARDS_DIR}/${EXTENSION_DASHBOARD_SUBDIR}/${CTEST_SCRIPT_NAME}.driver)
   file(DOWNLOAD ${url} ${dest} STATUS status)
   if(NOT status MATCHES "0.*")

--- a/metroplex-slicer_41120200930_release_package.sh
+++ b/metroplex-slicer_41120200930_release_package.sh
@@ -14,12 +14,12 @@ docker_args+=" -e run_ctest_with_test=${run_ctest_with_test-FALSE}" # XXX Re-ena
 docker_args+=" -e run_extension_ctest_with_test=${run_extension_ctest_with_test-FALSE}" # XXX Re-enable testing after slicer/slicer-test images have been updated
 
 # Slicer 'Stable' release
-time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-4.10 \
+time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-4.11-2020.09.30 \
   --args "${docker_args}" \
-  ctest -S /work/DashboardScripts/metroplex-slicer_4102_release_package.cmake -VV -O /work/Logs/metroplex-slicer_4102_release_package.log
+  ctest -S /work/DashboardScripts/metroplex-slicer_41120200930_release_package.cmake -VV -O /work/Logs/metroplex-slicer_41120200930_release_package.log
 
 # Slicer 'Stable' release extensions
-time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-4.10 \
+time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-4.11-2020.09.30 \
    --args "${docker_args}" \
    ctest -S /work/DashboardScripts/metroplex-slicerextensions_stable_nightly.cmake -VV -O /work/Logs/metroplex-slicerextensions_stable_nightly.log
 

--- a/metroplex-slicerextensions_stable_nightly.cmake
+++ b/metroplex-slicerextensions_stable_nightly.cmake
@@ -11,26 +11,27 @@ dashboard_set(HOSTNAME              "metroplex")
 dashboard_set(OPERATING_SYSTEM      "Linux")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "Stable")         # (E)xperimental, (P)review or (S)table
-dashboard_set(EXTENSIONS_INDEX_BRANCH "4.10")          # "master", X.Y, ...
+dashboard_set(EXTENSIONS_INDEX_BRANCH "4.11")          # "master", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "g++-5.3.1")      # Used only to set the build name
-dashboard_set(CTEST_BUILD_FLAGS     "")               # Use multiple CPU cores to build
+dashboard_set(CTEST_BUILD_FLAGS     "-j5 -l4")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
 #dashboard_set(CMAKE_CXX_COMPILER    "/path/to/cxx/compiler")
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.11.2")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.1")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "4102")      # Set to arbitrary integer to distinguish different Experimental/Preview release build
+# 0: 41120200930
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")      # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 dashboard_set(Slicer_SOURCE_DIR "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}")
 dashboard_set(Slicer_DIR        "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}-build/Slicer-build")

--- a/metroplex.sh
+++ b/metroplex.sh
@@ -61,7 +61,7 @@ time ${slicer_preview_script} \
   ctest -S /work/DashboardScripts/metroplex-slicerextensions_preview_nightly.cmake -VV -O /work/Logs/metroplex-slicerextensions_preview_nightly.log
 
 # Slicer 'Stable' release extensions
-time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-4.10 \
+time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-4.11 \
    --args "${docker_args}" \
    ctest -S /work/DashboardScripts/metroplex-slicerextensions_stable_nightly.cmake -VV -O /work/Logs/metroplex-slicerextensions_stable_nightly.log
 

--- a/overload-vs2019-slicer_41120200930_release_package.bat
+++ b/overload-vs2019-slicer_41120200930_release_package.bat
@@ -5,10 +5,10 @@
 :: Build Slicer
 :: ----------------------------------------------------------------------------
 ::echo "Slicer 'Stable' release"
-"C:\cmake-3.12.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2015-slicer_4102_release_package.cmake" -C Release -VV -O D:\D\Logs\overload-vs2015-slicer_4102_release_package.txt
+"C:\cmake-3.17.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicer_41120200930_release_package.cmake" -C Release -VV -O D:\D\Logs\overload-vs2015-slicer_41120200930_release_package.txt
 
 :: ----------------------------------------------------------------------------
 :: Build Slicer Extensions
 :: ----------------------------------------------------------------------------
 ::echo "Slicer 'Stable' release extensions"
-"C:\cmake-3.12.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2015-slicerextensions_stable_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2015-slicerextensions_stable_nightly.txt
+"C:\cmake-3.17.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_stable_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_stable_nightly.txt

--- a/overload-vs2019-slicer_41120200930_release_package.cmake
+++ b/overload-vs2019-slicer_41120200930_release_package.cmake
@@ -5,21 +5,22 @@ macro(dashboard_set var value)
   endif()
 endmacro()
 
-dashboard_set(DASHBOARDS_DIR        "/Volumes/D")
+dashboard_set(DASHBOARDS_DIR        "D:/D/")
 dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
-dashboard_set(HOSTNAME              "factory-south-macos")
-dashboard_set(OPERATING_SYSTEM      "macOS")
+dashboard_set(HOSTNAME              "overload")
+dashboard_set(OPERATING_SYSTEM      "Windows10")
 dashboard_set(SCRIPT_MODE           "Experimental")   # Experimental, Continuous or Nightly
-dashboard_set(Slicer_RELEASE_TYPE   "Stable")         # (E)xperimental, (P)review or (S)table
+dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
-dashboard_set(SVN_REVISION          "28257")          # Specify a revision for Stable release
-dashboard_set(SVN_BRANCH            "branches/Slicer-4-10")
+dashboard_set(GIT_TAG               "v4.11.20200930") # Specify a tag for Stable release
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
-dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "clang-8.0.0")    # Used only to set the build name
-dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
+dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 16 2019")
+dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
+dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v142")
+dashboard_set(COMPILER              "VS2019")         # Used only to set the build name
+dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
 #dashboard_set(CMAKE_CXX_COMPILER    "/path/to/cxx/compiler")
@@ -30,32 +31,37 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.10.0")
-dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/qt-everywhere-build-${QT_VERSION}/lib/cmake/Qt5")
+dashboard_set(QT_VERSION          "5.15.1")
+dashboard_set(Qt5_DIR             "D:/Support/Qt2/${QT_VERSION}/msvc2019_64/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Build directory  : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "4102")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
+# 0: 41120200930
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 
-# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
+# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoConsole][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
 set(BUILD_NAME_SUFFIX "")
 
 set(TEST_TO_EXCLUDE_REGEX "")
 
 set(ADDITIONAL_CMAKECACHE_OPTION "
+ADDITIONAL_C_FLAGS:STRING=/MP4
+ADDITIONAL_CXX_FLAGS:STRING=/MP4
 ")
 
 # Custom settings
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
+set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
+set(CTEST_SVN_COMMAND "C:/SlikSvn/bin/svn.exe")
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #
 ##########################################
 if(NOT DEFINED DRIVER_SCRIPT)
-  set(url http://svn.slicer.org/Slicer4/trunk/CMake/SlicerDashboardDriverScript.cmake)
+  set(url https://raw.githubusercontent.com/Slicer/Slicer/master/CMake/SlicerDashboardDriverScript.cmake)
   set(dest ${DASHBOARDS_DIR}/${EXTENSION_DASHBOARD_SUBDIR}/${CTEST_SCRIPT_NAME}.driver)
   file(DOWNLOAD ${url} ${dest} STATUS status)
   if(NOT status MATCHES "0.*")
@@ -64,4 +70,3 @@ if(NOT DEFINED DRIVER_SCRIPT)
   set(DRIVER_SCRIPT ${dest})
 endif()
 include(${DRIVER_SCRIPT})
-

--- a/overload-vs2019-slicerextensions_stable_nightly.cmake
+++ b/overload-vs2019-slicerextensions_stable_nightly.cmake
@@ -11,14 +11,14 @@ dashboard_set(HOSTNAME              "overload")
 dashboard_set(OPERATING_SYSTEM      "Windows10")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
-dashboard_set(EXTENSIONS_INDEX_BRANCH "4.10")          # "master", X.Y, ...
+dashboard_set(EXTENSIONS_INDEX_BRANCH "4.11")          # "master", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 16 2019")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
-dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v140")
-dashboard_set(COMPILER              "VS2015")         # Used only to set the build name
+dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v142")
+dashboard_set(COMPILER              "VS2019")         # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
@@ -26,13 +26,14 @@ dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.10.1")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.1")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
-dashboard_set(Slicer_DASHBOARD_SUBDIR     "S")
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "4102")      # Set to arbitrary integer to distinguish different Experimental/Preview release build
+dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
+# 0: 41120200930
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")      # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 dashboard_set(Slicer_SOURCE_DIR "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}")
 dashboard_set(Slicer_DIR        "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}-build/Slicer-build")

--- a/overload.bat
+++ b/overload.bat
@@ -40,7 +40,7 @@ call :fastdel "D:\D\P\Slicer-0-build"
 :: Build Slicer Extensions
 :: ----------------------------------------------------------------------------
 call :fastdel "D:\D\P\S-0-E-b"
-call :fastdel "D:\D\S\S-4102-E-b"
+call :fastdel "D:\D\S\S-41120200930-E-b"
 if "%IS_WEEKEND%"=="1" (
   call :slicerextensions_stable_nightly
   call :slicerextensions_preview_nightly


### PR DESCRIPTION
* Follow instructions from https://github.com/Slicer/DashboardScripts/blob/master/maintenance/guides/rename-and-update-release-scripts.md
* Rename scripts from overload-vs2015-* to overload-vs2019-*
* Update stable scripts compiler/os/... to match value from corresponding
  preview scripts
* Update stable scripts to download  slicer version with tag v4.11.20200930
* Change Slicer_DIRECTORY_IDENTIFIER from 41120200930 to 0 to ensure
  patch remains short enough.