### PR TITLE
metroplex: Update compiler version reported in build name (5.3.1 to 7.3.1)

### DIFF
--- a/metroplex-slicer_preview_nightly.cmake
+++ b/metroplex-slicer_preview_nightly.cmake
@@ -17,7 +17,7 @@ if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Ninja")
-dashboard_set(COMPILER              "g++-5.3.1")      # Used only to set the build name
+dashboard_set(COMPILER              "g++-7.3.1")      # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "")               # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")

--- a/metroplex-slicerextensions_preview_nightly.cmake
+++ b/metroplex-slicerextensions_preview_nightly.cmake
@@ -16,7 +16,7 @@ if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "g++-5.3.1")      # Used only to set the build name
+dashboard_set(COMPILER              "g++-7.3.1")      # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "-j5 -l4")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")


### PR DESCRIPTION
The compiler version displayed on CDash is now consistent with the
compiler effectively used to compile.

For reference,  here is the output reported when configuring Slicer on metroplex:

```
-- Setting C++ standard
-- Setting C++ standard - C++11
-- The C compiler identification is GNU 7.3.1
-- The CXX compiler identification is GNU 7.3.1
-- Check for working C compiler: /opt/rh/devtoolset-7/root/usr/bin/gcc
-- Check for working C compiler: /opt/rh/devtoolset-7/root/usr/bin/gcc - works
[...]
```

Source: https://slicer.cdash.org/build/2452929