### PR TITLE
Update CMake and Visual Studio build tools

### DIFF
--- a/computron.sh
+++ b/computron.sh
@@ -1,10 +1,10 @@
-# CMAKE_VERSION=3.17.2 - This comment is used by the maintenance script to look up the cmake version
+# CMAKE_VERSION=3.22.1 - This comment is used by the maintenance script to look up the cmake version
 
 # Clear Slicer settings
 rm -rf /Users/svc-dashboard/.config/www.na-mic.org/
 
 # Slicer 'Preview' release
-/D/Support/CMake-3.17.2.app/Contents/bin/ctest -S /D/DashboardScripts/computron-slicer_preview_nightly.cmake -VV -O /D/Logs/computron-slicer_preview_nightly.log
+/D/Support/CMake-3.22.1.app/Contents/bin/ctest -S /D/DashboardScripts/computron-slicer_preview_nightly.cmake -VV -O /D/Logs/computron-slicer_preview_nightly.log
 
 # Slicer 'Preview' release extensions
-/D/Support/CMake-3.17.2.app/Contents/bin/ctest -S /D/DashboardScripts/computron-slicerextensions_preview_nightly.cmake -VV -O /D/Logs/factory-south-macos-slicerextensions_preview_nightly.log
+/D/Support/CMake-3.22.1.app/Contents/bin/ctest -S /D/DashboardScripts/computron-slicerextensions_preview_nightly.cmake -VV -O /D/Logs/factory-south-macos-slicerextensions_preview_nightly.log

--- a/factory-south-macos.sh
+++ b/factory-south-macos.sh
@@ -1,4 +1,4 @@
-# CMAKE_VERSION=3.17.2 - This comment is used by the maintenance script to look up the cmake version
+# CMAKE_VERSION=3.22.1 - This comment is used by the maintenance script to look up the cmake version
 
 # To facilitate execution of the command below by copy/paste, they do not include variables.
 
@@ -6,25 +6,25 @@
 rm -rf /Users/kitware/.config/www.na-mic.org/
 
 # Slicer 'Preview' release
-/Volumes/D/Support/CMake-3.17.2.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicer_preview_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicer_preview_nightly.log
+/Volumes/D/Support/CMake-3.22.1.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicer_preview_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicer_preview_nightly.log
 
 # Slicer 'Preview' release extensions
-/Volumes/D/Support/CMake-3.17.2.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicerextensions_preview_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicerextensions_preview_nightly.log
+/Volumes/D/Support/CMake-3.22.1.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicerextensions_preview_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicerextensions_preview_nightly.log
 
 # Slicer 'Stable' release extensions
-/Volumes/D/Support/CMake-3.17.2.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicerextensions_stable_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicerextensions_stable_nightly.log
+/Volumes/D/Support/CMake-3.22.1.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicerextensions_stable_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicerextensions_stable_nightly.log
 
 # Clear SlicerSALT settings
 rm -rf /Users/kitware/.config/kitware.com/
 
 # SlicerSALT 'Preview' release
-/Volumes/D/Support/CMake-3.17.2.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicersalt_preview_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicersalt_preview_nightly.log
+/Volumes/D/Support/CMake-3.22.1.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicersalt_preview_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicersalt_preview_nightly.log
 
 # SlicerSALT 'Preview' release - generate package
-/Volumes/D/Support/CMake-3.17.2.app/Contents/bin/cmake --build /Volumes/D/P/SSALT-0-build/Slicer-build --target package --config Release > /Volumes/D/Logs/factory-south-macos-slicersalt-generate-package.txt 2>&1
+/Volumes/D/Support/CMake-3.22.1.app/Contents/bin/cmake --build /Volumes/D/P/SSALT-0-build/Slicer-build --target package --config Release > /Volumes/D/Logs/factory-south-macos-slicersalt-generate-package.txt 2>&1
 
 # SlicerSALT 'Preview' release - package upload
-/Volumes/D/Support/CMake-3.17.2.app/Contents/bin/cmake -P /Volumes/D/DashboardScripts/scripts/slicersalt-upload-package.cmake > /Volumes/D/Logs/factory-south-macos-slicersalt-upload-package.txt 2>&1
+/Volumes/D/Support/CMake-3.22.1.app/Contents/bin/cmake -P /Volumes/D/DashboardScripts/scripts/slicersalt-upload-package.cmake > /Volumes/D/Logs/factory-south-macos-slicersalt-upload-package.txt 2>&1
 
 #Medical Team Dashboard
 /Volumes/D/Med/MedicalTeamDashboardScripts/factory-macos-south.sh > /Volumes/D/Med/Logs/factory-macos-south.log 2>&1

--- a/maintenance/computron/remote-install-cmake.sh
+++ b/maintenance/computron/remote-install-cmake.sh
@@ -16,6 +16,19 @@ echo "cmake_version [${cmake_version}]"
 
 remote_support_dir="/D/Support"
 
+x=$(echo $cmake_version | cut -d- -f1 | cut -d. -f1)  # 3 given "3.11.0-rc3"
+y=$(echo $cmake_version | cut -d- -f1 | cut -d. -f2)  # 11 given "3.11.0-rc3"
+z=$(echo $cmake_version | cut -d- -f1 | cut -d. -f3)  # 0 given "3.11.0-rc3"
+
+# Starting with 3.19.2, "macos-universal" is distributed instead of "Darwin-x86_64"
+if [[ $x -ge 3 && $y -ge 19 && $z -ge 2 ]]; then
+  cmake_dirname=cmake-${cmake_version}-macos-universal
+else
+  cmake_dirname=cmake-${cmake_version}-Darwin-x86_64
+fi
+
+echo "cmake_dirname [${cmake_dirname}]"
+
 #------------------------------------------------------------------------------
 # Generate script
 #
@@ -28,13 +41,13 @@ set -ex
 
 cd $remote_support_dir
 
-rm -rf CMake-${cmake_version}.app cmake-${cmake_version}-Darwin-x86_64*
+rm -rf CMake-${cmake_version}.app \$(ls -1 | grep "^${cmake_dirname}")
 
-curl -LO "https://github.com/Kitware/CMake/releases/download/v${cmake_version}/cmake-${cmake_version}-Darwin-x86_64.tar.gz"
-tar -xvf cmake-${cmake_version}-Darwin-x86_64.tar.gz
+curl -LO "https://github.com/Kitware/CMake/releases/download/v${cmake_version}/${cmake_dirname}.tar.gz"
+tar -xvf ${cmake_dirname}.tar.gz
 
-mv cmake-${cmake_version}-Darwin-x86_64/CMake.app CMake-${cmake_version}.app
-rm -rf cmake-${cmake_version}-Darwin-x86_64*
+mv ${cmake_dirname}/CMake.app CMake-${cmake_version}.app
+rm -rf \$(ls -1 | grep "^${cmake_dirname}")
 
 ./CMake-${cmake_version}.app/Contents/bin/cmake --version
 

--- a/maintenance/factory-south-macos/remote-install-cmake.sh
+++ b/maintenance/factory-south-macos/remote-install-cmake.sh
@@ -16,6 +16,19 @@ echo "cmake_version [${cmake_version}]"
 
 remote_support_dir="/Volumes/D/Support"
 
+x=$(echo $cmake_version | cut -d- -f1 | cut -d. -f1)  # 3 given "3.11.0-rc3"
+y=$(echo $cmake_version | cut -d- -f1 | cut -d. -f2)  # 11 given "3.11.0-rc3"
+z=$(echo $cmake_version | cut -d- -f1 | cut -d. -f3)  # 0 given "3.11.0-rc3"
+
+# Starting with 3.19.2, "macos-universal" is distributed instead of "Darwin-x86_64"
+if [[ $x -ge 3 && $y -ge 19 && $z -ge 2 ]]; then
+  cmake_dirname=cmake-${cmake_version}-macos-universal
+else
+  cmake_dirname=cmake-${cmake_version}-Darwin-x86_64
+fi
+
+echo "cmake_dirname [${cmake_dirname}]"
+
 #------------------------------------------------------------------------------
 # Generate script
 #
@@ -28,13 +41,13 @@ set -ex
 
 cd $remote_support_dir
 
-rm -rf CMake-${cmake_version}.app cmake-${cmake_version}-Darwin-x86_64*
+rm -rf CMake-${cmake_version}.app \$(ls -1 | grep "^${cmake_dirname}")
 
-curl -LO "https://github.com/Kitware/CMake/releases/download/v${cmake_version}/cmake-${cmake_version}-Darwin-x86_64.tar.gz"
-tar -xvf cmake-${cmake_version}-Darwin-x86_64.tar.gz
+curl -LO "https://github.com/Kitware/CMake/releases/download/v${cmake_version}/${cmake_dirname}.tar.gz"
+tar -xvf ${cmake_dirname}.tar.gz
 
-mv cmake-${cmake_version}-Darwin-x86_64/CMake.app CMake-${cmake_version}.app
-rm -rf cmake-${cmake_version}-Darwin-x86_64*
+mv ${cmake_dirname}/CMake.app CMake-${cmake_version}.app
+rm -rf \$(ls -1 | grep "^${cmake_dirname}")
 
 ./CMake-${cmake_version}.app/Contents/bin/cmake --version
 

--- a/overload-vs2022-slicer_preview_nightly.cmake
+++ b/overload-vs2022-slicer_preview_nightly.cmake
@@ -16,10 +16,10 @@ dashboard_set(GIT_TAG               "master")         # Specify a tag for Stable
 if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
-dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 16 2019")
+dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
-dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v142")
-dashboard_set(COMPILER              "VS2019")         # Used only to set the build name
+dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v143")
+dashboard_set(COMPILER              "VS2022")         # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")

--- a/overload-vs2022-slicerextensions_preview_nightly.cmake
+++ b/overload-vs2022-slicerextensions_preview_nightly.cmake
@@ -15,10 +15,10 @@ dashboard_set(EXTENSIONS_INDEX_BRANCH "master")       # "master", X.Y, ...
 if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
-dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 16 2019")
+dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
-dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v142")
-dashboard_set(COMPILER              "VS2019")         # Used only to set the build name
+dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v143")
+dashboard_set(COMPILER              "VS2022")         # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")

--- a/overload.bat
+++ b/overload.bat
@@ -34,7 +34,7 @@ call :fastdel "C:\Users\svc-dashboard\AppData\Roaming\NA-MIC"
 :: ----------------------------------------------------------------------------
 ::echo "Slicer 'Preview' release"
 call :fastdel "D:\D\P\Slicer-0-build"
-"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicer_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicer_preview_nightly.txt
+"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicer_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicer_preview_nightly.txt
 
 :: ----------------------------------------------------------------------------
 :: Build Slicer Extensions
@@ -78,7 +78,7 @@ EXIT /B %ERRORLEVEL%
 :: ----------------------------------------------------------------------------
 :slicerextensions_preview_nightly
 ::echo "Slicer 'Preview' release extensions"
-"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_preview_nightly.txt
+"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicerextensions_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicerextensions_preview_nightly.txt
 EXIT /B 0
 
 :: ----------------------------------------------------------------------------

--- a/overload.bat
+++ b/overload.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 
-:: CMAKE_VERSION=3.17.2 - This comment is used by the maintenance script to look up the cmake version
+:: CMAKE_VERSION=3.22.1 - This comment is used by the maintenance script to look up the cmake version
 
 :: To facilitate execution of the command below by copy/paste, they do not include variables.
 
@@ -34,7 +34,7 @@ call :fastdel "C:\Users\svc-dashboard\AppData\Roaming\NA-MIC"
 :: ----------------------------------------------------------------------------
 ::echo "Slicer 'Preview' release"
 call :fastdel "D:\D\P\Slicer-0-build"
-"C:\cmake-3.17.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicer_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicer_preview_nightly.txt
+"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicer_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicer_preview_nightly.txt
 
 :: ----------------------------------------------------------------------------
 :: Build Slicer Extensions
@@ -78,13 +78,13 @@ EXIT /B %ERRORLEVEL%
 :: ----------------------------------------------------------------------------
 :slicerextensions_preview_nightly
 ::echo "Slicer 'Preview' release extensions"
-"C:\cmake-3.17.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_preview_nightly.txt
+"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_preview_nightly.txt
 EXIT /B 0
 
 :: ----------------------------------------------------------------------------
 :slicerextensions_stable_nightly
 ::echo "Slicer 'Stable' release extensions"
-"C:\cmake-3.17.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_stable_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_stable_nightly.txt
+"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_stable_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_stable_nightly.txt
 EXIT /B 0
 
 :: ----------------------------------------------------------------------------


### PR DESCRIPTION
This PR includes multiple build tools updates all together as they would likely be updated all at the same time by @sjh26 or @jcfr .

Updating the CMake version to 3.22.0 which includes a bug fix that should resolve uninstall issues of factory-built Slicer versions on Windows. See Slicer/Slicer#4933. It is being updated for both preview and stable build configurations.
- [x] overload: install CMake 3.22.1
- [x] computron: install CMake 3.22.1
- [x] factory-south-macos: install CMake 3.22.1

Note that I've only updated Slicer preview build and preview extensions build to use VS2022 with v143 toolset. I have not modified the files for Slicer Stable. These could be changed once a new Stable is defined. I also am not changing SlicerSalt or CellLocator to use the newer Visual Studio due to them likely using older Slicer versions that won't build successfully with the latest toolset.

Visual Studio 2022 biggest change is itself is now a 64-bit application.
- [x] overload: install Visual Studio 2022 with "Desktop Development with C++" workload install option which includes v143 toolset. v142, v141 and v140 toolsets are all available if older Visual Studio IDEs are desired to be removed as well. VS2022 can be installed side-by-side with VS2019.