### PR TITLE
Rename and update Slicer release scripts from 4.11.20210226 to 5.0.0

### DIFF
--- a/factory-south-macos-slicer_41120210226_release_package.sh
+++ b/factory-south-macos-slicer_41120210226_release_package.sh
@@ -1,7 +1,0 @@
-# CMAKE_VERSION=NA - This comment is used by the maintenance script to look up the cmake version
-
-# Slicer 'Stable' release
-/Volumes/D/Support/CMake-3.15.1.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicer_41120210226_release_package.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicer_41120210226_release_package.log
-
-# Slicer 'Stable' release extensions
-/Volumes/D/Support/CMake-3.15.1.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicerextensions_stable_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicerextensions_stable_nightly.log

--- a/factory-south-macos-slicer_500_release_package.cmake
+++ b/factory-south-macos-slicer_500_release_package.cmake
@@ -5,22 +5,20 @@ macro(dashboard_set var value)
   endif()
 endmacro()
 
-dashboard_set(DASHBOARDS_DIR        "D:/D/")
+dashboard_set(DASHBOARDS_DIR        "/Volumes/D")
 dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
-dashboard_set(HOSTNAME              "overload")
-dashboard_set(OPERATING_SYSTEM      "Windows10")
+dashboard_set(HOSTNAME              "factory-south-macos")
+dashboard_set(OPERATING_SYSTEM      "macOS")
 dashboard_set(SCRIPT_MODE           "Experimental")   # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
-dashboard_set(GIT_TAG               "v4.11.20210226") # Specify a tag for Stable release
+dashboard_set(GIT_TAG               "v5.0.0") # Specify a tag for Stable release
 if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
-dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 16 2019")
-dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
-dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v142")
-dashboard_set(COMPILER              "VS2019")         # Used only to set the build name
-dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
+dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+dashboard_set(COMPILER              "clang-10.0.0")    # Used only to set the build name
+dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
 #dashboard_set(CMAKE_CXX_COMPILER    "/path/to/cxx/compiler")
@@ -31,31 +29,27 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.15.1")
-dashboard_set(Qt5_DIR             "D:/Support/Qt2/${QT_VERSION}/msvc2019_64/lib/cmake/Qt5")
+dashboard_set(QT_VERSION          "5.15.2")
+dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/qt-everywhere-build-${QT_VERSION}/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Build directory  : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
-dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
+dashboard_set(Slicer_DIRECTORY_BASENAME   "S")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-# 1: 41120210226
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "1")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
+# 0: 500
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 
-# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoConsole][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
+# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
 set(BUILD_NAME_SUFFIX "")
 
 set(TEST_TO_EXCLUDE_REGEX "")
 
 set(ADDITIONAL_CMAKECACHE_OPTION "
-ADDITIONAL_C_FLAGS:STRING=/MP4
-ADDITIONAL_CXX_FLAGS:STRING=/MP4
 ")
 
 # Custom settings
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
-set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
-set(CTEST_SVN_COMMAND "C:/SlikSvn/bin/svn.exe")
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #
@@ -70,3 +64,4 @@ if(NOT DEFINED DRIVER_SCRIPT)
   set(DRIVER_SCRIPT ${dest})
 endif()
 include(${DRIVER_SCRIPT})
+

--- a/factory-south-macos-slicer_500_release_package.sh
+++ b/factory-south-macos-slicer_500_release_package.sh
@@ -1,0 +1,7 @@
+# CMAKE_VERSION=NA - This comment is used by the maintenance script to look up the cmake version
+
+# Slicer 'Stable' release
+/Volumes/D/Support/CMake-3.22.1.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicer_500_release_package.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicer_500_release_package.log
+
+# Slicer 'Stable' release extensions
+/Volumes/D/Support/CMake-3.22.1.app/Contents/bin/ctest -S /Volumes/D/DashboardScripts/factory-south-macos-slicerextensions_stable_nightly.cmake -VV -O /Volumes/D/Logs/factory-south-macos-slicerextensions_stable_nightly.log

--- a/factory-south-macos-slicerextensions_stable_nightly.cmake
+++ b/factory-south-macos-slicerextensions_stable_nightly.cmake
@@ -11,7 +11,7 @@ dashboard_set(HOSTNAME              "factory-south-macos")
 dashboard_set(OPERATING_SYSTEM      "macOS")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
-dashboard_set(EXTENSIONS_INDEX_BRANCH "4.11")          # "master", X.Y, ...
+dashboard_set(EXTENSIONS_INDEX_BRANCH "5.0")          # "master", X.Y, ...
 if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
@@ -24,14 +24,14 @@ dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.15.1")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.2")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "S")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-#0: 41120200930
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "1")      # Set to arbitrary integer to distinguish different Experimental/Preview release build
+# 0: 500
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 dashboard_set(Slicer_SOURCE_DIR "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}")
 dashboard_set(Slicer_DIR        "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}-build/Slicer-build")

--- a/metroplex-slicer_500_release_package.cmake
+++ b/metroplex-slicer_500_release_package.cmake
@@ -12,12 +12,12 @@ dashboard_set(OPERATING_SYSTEM      "Linux")
 dashboard_set(SCRIPT_MODE           "Experimental")   # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "Stable")         # (E)xperimental, (P)review or (S)table
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
-dashboard_set(GIT_TAG               "v4.11.20210226") # Specify a tag for Stable release
+dashboard_set(GIT_TAG               "v5.0.0")         # Specify a tag for Stable release
 if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Ninja")
-dashboard_set(COMPILER              "g++-5.3.1")      # Used only to set the build name
+dashboard_set(COMPILER              "g++-7.3.1")      # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "")               # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
@@ -29,15 +29,15 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.15.1")
+dashboard_set(QT_VERSION          "5.15.2")
 dashboard_set(Qt5_DIR             "$ENV{Qt5_DIR}")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Build directory  : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-# 1: 41120210226
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "1")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
+# 0: 500
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 
 # Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION

--- a/metroplex-slicer_500_release_package.sh
+++ b/metroplex-slicer_500_release_package.sh
@@ -14,12 +14,12 @@ docker_args+=" -e run_ctest_with_test=${run_ctest_with_test-FALSE}" # XXX Re-ena
 docker_args+=" -e run_extension_ctest_with_test=${run_extension_ctest_with_test-FALSE}" # XXX Re-enable testing after slicer/slicer-test images have been updated
 
 # Slicer 'Stable' release
-time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-4.11-2021.02.26 \
+time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-5.0 \
   --args "${docker_args}" \
-  ctest -S /work/DashboardScripts/metroplex-slicer_41120210226_release_package.cmake -VV -O /work/Logs/metroplex-slicer_41120210226_release_package.log
+  ctest -S /work/DashboardScripts/metroplex-slicer_500_release_package.cmake -VV -O /work/Logs/metroplex-slicer_500_release_package.log
 
 # Slicer 'Stable' release extensions
-time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-4.11-2021.02.26 \
+time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-5.0 \
    --args "${docker_args}" \
    ctest -S /work/DashboardScripts/metroplex-slicerextensions_stable_nightly.cmake -VV -O /work/Logs/metroplex-slicerextensions_stable_nightly.log
 

--- a/metroplex-slicerextensions_stable_nightly.cmake
+++ b/metroplex-slicerextensions_stable_nightly.cmake
@@ -11,12 +11,12 @@ dashboard_set(HOSTNAME              "metroplex")
 dashboard_set(OPERATING_SYSTEM      "Linux")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "Stable")         # (E)xperimental, (P)review or (S)table
-dashboard_set(EXTENSIONS_INDEX_BRANCH "4.11")          # "master", X.Y, ...
+dashboard_set(EXTENSIONS_INDEX_BRANCH "5.0")          # "master", X.Y, ...
 if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "g++-5.3.1")      # Used only to set the build name
+dashboard_set(COMPILER              "g++-7.3.1")      # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "-j5 -l4")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
@@ -24,14 +24,14 @@ dashboard_set(CTEST_BUILD_FLAGS     "-j5 -l4")        # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.15.1")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.2")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-# 0: 41120200930
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "1")      # Set to arbitrary integer to distinguish different Experimental/Preview release build
+# 0: 500
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 dashboard_set(Slicer_SOURCE_DIR "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}")
 dashboard_set(Slicer_DIR        "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}-build/Slicer-build")

--- a/metroplex.sh
+++ b/metroplex.sh
@@ -60,7 +60,7 @@ time ${slicer_preview_script} \
   ctest -S /work/DashboardScripts/metroplex-slicerextensions_preview_nightly.cmake -VV -O /work/Logs/metroplex-slicerextensions_preview_nightly.log
 
 # Slicer 'Stable' release extensions
-time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-4.11-2020.09.30 \
+time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-5.0 \
    --args "${docker_args}" \
    ctest -S /work/DashboardScripts/metroplex-slicerextensions_stable_nightly.cmake -VV -O /work/Logs/metroplex-slicerextensions_stable_nightly.log
 

--- a/overload-vs2022-slicer_500_release_package.bat
+++ b/overload-vs2022-slicer_500_release_package.bat
@@ -5,10 +5,10 @@
 :: Build Slicer
 :: ----------------------------------------------------------------------------
 ::echo "Slicer 'Stable' release"
-"C:\cmake-3.17.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicer_41120210226_release_package.cmake" -C Release -VV -O D:\D\Logs\overload-vs2015-slicer_41120210226_release_package.txt
+"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicer_500_release_package.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicer_500_release_package.txt
 
 :: ----------------------------------------------------------------------------
 :: Build Slicer Extensions
 :: ----------------------------------------------------------------------------
 ::echo "Slicer 'Stable' release extensions"
-"C:\cmake-3.17.2\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_stable_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_stable_nightly.txt
+"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicerextensions_stable_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicerextensions_stable_nightly.txt

--- a/overload-vs2022-slicer_500_release_package.cmake
+++ b/overload-vs2022-slicer_500_release_package.cmake
@@ -5,20 +5,22 @@ macro(dashboard_set var value)
   endif()
 endmacro()
 
-dashboard_set(DASHBOARDS_DIR        "/Volumes/D")
+dashboard_set(DASHBOARDS_DIR        "D:/D/")
 dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
-dashboard_set(HOSTNAME              "factory-south-macos")
-dashboard_set(OPERATING_SYSTEM      "macOS")
+dashboard_set(HOSTNAME              "overload")
+dashboard_set(OPERATING_SYSTEM      "Windows10")
 dashboard_set(SCRIPT_MODE           "Experimental")   # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
-dashboard_set(GIT_TAG               "v4.11.20210226") # Specify a tag for Stable release
+dashboard_set(GIT_TAG               "v5.0.0")         # Specify a tag for Stable release
 if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
-dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "clang-10.0.0")    # Used only to set the build name
-dashboard_set(CTEST_BUILD_FLAGS     "-j9 -l8")        # Use multiple CPU cores to build. For example "-j -l4" on unix
+dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
+dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
+dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v143")
+dashboard_set(COMPILER              "VS2022")         # Used only to set the build name
+dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
 #dashboard_set(CMAKE_CXX_COMPILER    "/path/to/cxx/compiler")
@@ -29,27 +31,31 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.15.1")
-dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/qt-everywhere-build-${QT_VERSION}/lib/cmake/Qt5")
+dashboard_set(QT_VERSION          "5.15.2")
+dashboard_set(Qt5_DIR             "D:/Support/Qt2/${QT_VERSION}/msvc2019_64/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Build directory  : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
 dashboard_set(Slicer_DIRECTORY_BASENAME   "S")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-# 1: 41120210226
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "1")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
+# 0: 500
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 
-# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
+# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoConsole][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
 set(BUILD_NAME_SUFFIX "")
 
 set(TEST_TO_EXCLUDE_REGEX "")
 
 set(ADDITIONAL_CMAKECACHE_OPTION "
+ADDITIONAL_C_FLAGS:STRING=/MP4
+ADDITIONAL_CXX_FLAGS:STRING=/MP4
 ")
 
 # Custom settings
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
+set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
+set(CTEST_SVN_COMMAND "C:/SlikSvn/bin/svn.exe")
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #
@@ -64,4 +70,3 @@ if(NOT DEFINED DRIVER_SCRIPT)
   set(DRIVER_SCRIPT ${dest})
 endif()
 include(${DRIVER_SCRIPT})
-

--- a/overload-vs2022-slicerextensions_stable_nightly.cmake
+++ b/overload-vs2022-slicerextensions_stable_nightly.cmake
@@ -11,14 +11,14 @@ dashboard_set(HOSTNAME              "overload")
 dashboard_set(OPERATING_SYSTEM      "Windows10")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
-dashboard_set(EXTENSIONS_INDEX_BRANCH "4.11")          # "master", X.Y, ...
+dashboard_set(EXTENSIONS_INDEX_BRANCH "5.0")          # "master", X.Y, ...
 if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
-dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 16 2019")
+dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
-dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v142")
-dashboard_set(COMPILER              "VS2019")         # Used only to set the build name
+dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v143")
+dashboard_set(COMPILER              "VS2022")         # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
@@ -26,14 +26,14 @@ dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.15.1")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.2")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
-dashboard_set(Slicer_DIRECTORY_BASENAME   "Slicer")
+dashboard_set(Slicer_DIRECTORY_BASENAME   "S")
 dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
-# 0: 41120200930
-dashboard_set(Slicer_DIRECTORY_IDENTIFIER "1")      # Set to arbitrary integer to distinguish different Experimental/Preview release build
+# 0: 500
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
                                                       # Set to Slicer version XYZ for Stable release build
 dashboard_set(Slicer_SOURCE_DIR "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}")
 dashboard_set(Slicer_DIR        "${DASHBOARDS_DIR}/${Slicer_DASHBOARD_SUBDIR}/${Slicer_DIRECTORY_BASENAME}-${Slicer_DIRECTORY_IDENTIFIER}-build/Slicer-build")

--- a/overload.bat
+++ b/overload.bat
@@ -40,7 +40,7 @@ call :fastdel "D:\D\P\Slicer-0-build"
 :: Build Slicer Extensions
 :: ----------------------------------------------------------------------------
 call :fastdel "D:\D\P\S-0-E-b"
-call :fastdel "D:\D\S\S-1-E-b"
+call :fastdel "D:\D\S\S-0-E-b"
 if "%IS_WEEKEND%"=="1" (
   call :slicerextensions_stable_nightly
   call :slicerextensions_preview_nightly
@@ -84,7 +84,7 @@ EXIT /B 0
 :: ----------------------------------------------------------------------------
 :slicerextensions_stable_nightly
 ::echo "Slicer 'Stable' release extensions"
-"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2019-slicerextensions_stable_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_stable_nightly.txt
+"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicerextensions_stable_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_stable_nightly.txt
 EXIT /B 0
 
 :: ----------------------------------------------------------------------------


### PR DESCRIPTION
* Follow instructions from https://github.com/Slicer/DashboardScripts/blob/master/maintenance/guides/rename-and-update-release-scripts.md
* Remove scripts for `4.11.20210226`
* Associate 5.0.0 with directory identifier `0`
* Manually update `metroplex-slicer_500_release_package` to use
  correct docker image name.
* Update overload.bat to delete `D:\D\S\S-0-E-b` instead of `D:\D\S\S-1-E-b`