### PR TITLE
Ensure version is updated in shell scripts used to generate Stable package

### DIFF
--- a/maintenance/guides/rename-and-update-release-scripts.md
+++ b/maintenance/guides/rename-and-update-release-scripts.md
@@ -45,7 +45,6 @@ done
 # Update version references in scripts
 for script in \
     computron.sh \
-    factory-south-macos.sh \
     metroplex.sh \
     overload.bat \
     $(find -name "*slicerextensions_stable_nightly.cmake" -not -path "./.git/*" -not -name ".git*") \

--- a/maintenance/guides/rename-and-update-release-scripts.md
+++ b/maintenance/guides/rename-and-update-release-scripts.md
@@ -37,7 +37,7 @@ for script in \
     overload.bat \
     $(find -name "*slicerextensions_stable_nightly.cmake" -not -path "./.git/*" -not -name ".git*") \
     $(find -not -path "./.git/*" -not -name ".git*" | grep $TO_XY) \
-    $(find -name "*_stable_package.cmake" -not -path "./.git/*" -not -name ".git*") \
+    $(find -name "*_stable_package.*" -not -path "./.git/*" -not -name ".git*") \
   ; do
   echo "Updating $script"
   sed -i -e "s/$FROM_DOT/$TO_DOT/g" $script

--- a/maintenance/guides/rename-and-update-release-scripts.md
+++ b/maintenance/guides/rename-and-update-release-scripts.md
@@ -30,18 +30,6 @@ TO_XY=$(echo $TO_DOT_XY | sed "s/\.//g")
 echo "FROM_DOT [$FROM_DOT] FROM_DOT_XY [$FROM_DOT_XY] FROM_XYZ [$FROM_XYZ] FROM_XY [$FROM_XY]"
 echo "  TO_DOT [$TO_DOT]   TO_DOT_XY [$TO_DOT_XY]   TO_XYZ [$TO_XYZ]   TO_XY [$TO_XY]"
 
-# Copy scripts <host>_slicer_<FROM_XYZ|FROM_XY>.* to  <host>_slicer_<TO_XY>.*
-for script in $(find -not -path "./.git/*" -not -name ".git*" | grep "slicer\_" | grep $FROM_XY);  do
-  new_script=$(echo $script | sed "s/$FROM_XYZ/$TO_XY/g");
-  new_script=$(echo $new_script | sed "s/$FROM_XY/$TO_XY/g");
-  if [[ "$script" == "$new_script" ]]; then
-    echo "Found $new_script"
-  else
-    echo "Renamed $script to $new_script"
-    mv $script $new_script
-  fi
-done
-
 # Update version references in scripts
 for script in \
     computron.sh \

--- a/metroplex-slicer_stable_package.sh
+++ b/metroplex-slicer_stable_package.sh
@@ -8,7 +8,7 @@ echo "Job started at: $(date +'%T %D %Z')"
 cd  /home/kitware/Dashboards/Slicer
 
 SLICER_PREVIEW_ENV_NAME=qt5-centos7
-SLICER_PREVIEW_ENV_VERSION=slicer-5.4
+SLICER_PREVIEW_ENV_VERSION=slicer-5.6
 
 # Download build environment
 slicer_stable_script=/home/kitware/bin/slicer-buildenv-${SLICER_PREVIEW_ENV_NAME}-${SLICER_PREVIEW_ENV_VERSION}


### PR DESCRIPTION
This ensures that the script `metroplex-slicer_stable_package.sh` references the expected build environment, guaranteeing that its execution generates the correct build environment script, now named `slicer-buildenv-qt5-centos7-slicer-5.6`.

See https://discourse.slicer.org/t/no-stable-linux-extension-packages-since-nov-26th/33150/5