### PR TITLE
overload: Update SlicerAutoscoperM_CUDA_PATH from 11.8 to 12.3

### DIFF
--- a/overload-vs2022-slicerextensions_preview_nightly.cmake
+++ b/overload-vs2022-slicerextensions_preview_nightly.cmake
@@ -55,7 +55,7 @@ set(ADDITIONAL_CMAKECACHE_OPTION "
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
 set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
 set(ENV{FC} "C:\\Miniconda3\\envs\\flang-env\\Library\\bin\\flang.exe") # For LAPACKE
-set(ENV{SlicerAutoscoperM_CUDA_PATH} "$ENV{CUDA_PATH_V11_8}")
+set(ENV{SlicerAutoscoperM_CUDA_PATH} "$ENV{CUDA_PATH_V12_3}")
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #

--- a/overload-vs2022-slicerextensions_stable_nightly.cmake
+++ b/overload-vs2022-slicerextensions_stable_nightly.cmake
@@ -56,7 +56,7 @@ set(ADDITIONAL_CMAKECACHE_OPTION "
 include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
 set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
 set(ENV{FC} "C:\\Miniconda3\\envs\\flang-env\\Library\\bin\\flang.exe") # For LAPACKE
-set(ENV{SlicerAutoscoperM_CUDA_PATH} "$ENV{CUDA_PATH_V11_8}")
+set(ENV{SlicerAutoscoperM_CUDA_PATH} "$ENV{CUDA_PATH_V12_3}")
 
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #


### PR DESCRIPTION
Related:
* https://github.com/Slicer/DashboardScripts/pull/63
* https://github.com/BrownBiomechanics/Autoscoper/pull/258
* https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/81