### PR TITLE
bluestreak: Fix syntax and ensure preview extension builds are triggered

### DIFF
--- a/bluestreak.bat
+++ b/bluestreak.bat
@@ -48,13 +48,15 @@ call :fastdel "C:\D\P\S-0-build"
 :: ----------------------------------------------------------------------------
 call :fastdel "C:\D\P\S-0-E-b"
 call :fastdel "C:\D\S\S-0-E-b"
-if "%IS_WEEKEND%"=="1" (
+::if "%IS_WEEKEND%"=="1" (
 ::  call :slicerextensions_stable_nightly
-  call :slicerextensions_preview_nightly
-) else (
-  call :slicerextensions_preview_nightly
+::  call :slicerextensions_preview_nightly
+::) else (
+::  call :slicerextensions_preview_nightly
 ::  call :slicerextensions_stable_nightly
-)
+::)
+
+call :slicerextensions_preview_nightly
 
 :: ----------------------------------------------------------------------------
 :: Clean SlicerSALT settings


### PR DESCRIPTION
Follow-up of aba1c0c (`bluestreak/overload: Move SlicerPreview from "overload" to "bluestreak"`, 2024-04-29)

The commented `call` statements led to an invalid syntax. Instead, comment the complete block and explicitly call `slicerextensions_preview_nightly`