### PR TITLE
Restore overload preview build

### DIFF
--- a/overload-vs2022-slicer_preview_nightly.cmake
+++ b/overload-vs2022-slicer_preview_nightly.cmake
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.9)
+macro(dashboard_set var value)
+  if(NOT DEFINED "${var}")
+    set(${var} "${value}")
+  endif()
+endmacro()
+
+dashboard_set(DASHBOARDS_DIR        "D:/D/")
+dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
+dashboard_set(HOSTNAME              "overload")
+dashboard_set(OPERATING_SYSTEM      "Windows10")
+dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
+dashboard_set(Slicer_RELEASE_TYPE   "P")              # (E)xperimental, (P)review or (S)table
+dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
+dashboard_set(GIT_TAG               "main")         # Specify a tag for Stable release
+
+if(APPLE)
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
+endif()
+dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
+dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
+dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v143")
+dashboard_set(COMPILER              "VS2022")         # Used only to set the build name
+dashboard_set(CTEST_BUILD_FLAGS     "/maxcpucount:4") # Use multiple CPU cores to build. For example "-j -l4" on unix
+# By default, CMake auto-discovers the compilers
+#dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")
+#dashboard_set(CMAKE_CXX_COMPILER    "/path/to/cxx/compiler")
+dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
+dashboard_set(WITH_MEMCHECK       FALSE)
+dashboard_set(WITH_COVERAGE       FALSE)
+dashboard_set(WITH_DOCUMENTATION  FALSE)
+dashboard_set(Slicer_BUILD_CLI    ON)
+dashboard_set(Slicer_USE_PYTHONQT ON)
+
+dashboard_set(QT_VERSION          "5.15.2")
+dashboard_set(Qt5_DIR             "D:/Support/Qt2/${QT_VERSION}/msvc2019_64/lib/cmake/Qt5")
+
+#   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
+#   Build directory  : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build
+dashboard_set(Slicer_DIRECTORY_BASENAME   "S")
+dashboard_set(Slicer_DASHBOARD_SUBDIR     "${Slicer_RELEASE_TYPE}")
+
+dashboard_set(Slicer_DIRECTORY_IDENTIFIER "0")        # Set to arbitrary integer to distinguish different Experimental/Preview release build
+                                                      # Set to Slicer version XYZ for Stable release build
+
+# Build Name: <OPERATING_SYSTEM>-<COMPILER>-<BITNESS>bits-QT<QT_VERSION>[-NoPython][-NoCLI][-NoConsole][-NoVTKDebugLeaks][-<BUILD_NAME_SUFFIX>]-<CTEST_BUILD_CONFIGURATION
+set(BUILD_NAME_SUFFIX "")
+
+set(TEST_TO_EXCLUDE_REGEX "")
+
+set(ADDITIONAL_CMAKECACHE_OPTION "
+ADDITIONAL_C_FLAGS:STRING=/MP4
+ADDITIONAL_CXX_FLAGS:STRING=/MP4
+")
+
+# Custom settings
+include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
+set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
+set(CTEST_SVN_COMMAND "C:/SlikSvn/bin/svn.exe")
+
+##########################################
+# WARNING: DO NOT EDIT BEYOND THIS POINT #
+##########################################
+if(NOT DEFINED DRIVER_SCRIPT)
+  set(url https://raw.githubusercontent.com/Slicer/Slicer/main/CMake/SlicerDashboardDriverScript.cmake)
+  set(dest ${DASHBOARDS_DIR}/${EXTENSION_DASHBOARD_SUBDIR}/${CTEST_SCRIPT_NAME}.driver)
+  file(DOWNLOAD ${url} ${dest} STATUS status)
+  if(NOT status MATCHES "0.*")
+    message(FATAL_ERROR "error: Failed to download ${url} - ${status}")
+  endif()
+  set(DRIVER_SCRIPT ${dest})
+endif()
+include(${DRIVER_SCRIPT})

--- a/overload-vs2022-slicer_preview_nightly.cmake
+++ b/overload-vs2022-slicer_preview_nightly.cmake
@@ -58,6 +58,9 @@ include("${DASHBOARDS_DIR}/Support/Kitware-SlicerPackagesCredential.cmake")
 set(ENV{ExternalData_OBJECT_STORES} "${DASHBOARDS_DIR}/.ExternalData")
 set(CTEST_SVN_COMMAND "C:/SlikSvn/bin/svn.exe")
 
+set(run_ctest_with_packages FALSE)
+set(run_ctest_with_upload FALSE)
+
 ##########################################
 # WARNING: DO NOT EDIT BEYOND THIS POINT #
 ##########################################

--- a/overload.bat
+++ b/overload.bat
@@ -65,14 +65,14 @@ call :fastdel "C:\Users\svc-dashboard\AppData\Roaming\Kitware, Inc"
 :: Build SlicerSALT
 :: ----------------------------------------------------------------------------
 ::echo "SlicerSALT 'Preview' release"
-call :fastdel "D:\D\P\SSALT-0-build"
-"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicersalt_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicersalt_preview_nightly.txt
+::call :fastdel "D:\D\P\SSALT-0-build"
+::"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicersalt_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicersalt_preview_nightly.txt
 
 ::echo "SlicerSALT 'Preview' release - generate package"
-"C:\cmake-3.22.1\bin\cmake.exe" --build "D:\D\P\SSALT-0-build/Slicer-build" --target PACKAGE --config Release > D:\D\Logs\overload-slicersalt-generate-package.txt 2>&1
+::"C:\cmake-3.22.1\bin\cmake.exe" --build "D:\D\P\SSALT-0-build/Slicer-build" --target PACKAGE --config Release > D:\D\Logs\overload-slicersalt-generate-package.txt 2>&1
 
 ::echo "SlicerSALT 'Preview' release - package upload"
-"C:\cmake-3.22.1\bin\cmake.exe" -P "D:\D\DashboardScripts\scripts\slicersalt-upload-package.cmake" > D:\D\Logs\overload-slicersalt-upload-package.txt 2>&1
+::"C:\cmake-3.22.1\bin\cmake.exe" -P "D:\D\DashboardScripts\scripts\slicersalt-upload-package.cmake" > D:\D\Logs\overload-slicersalt-upload-package.txt 2>&1
 
 :: force execution to quit at the end of the "main" logic
 EXIT /B %ERRORLEVEL%

--- a/overload.bat
+++ b/overload.bat
@@ -31,6 +31,13 @@ echo IS_WEEKEND[%IS_WEEKEND%]
 call :fastdel "C:\Users\svc-dashboard\AppData\Roaming\slicer.org"
 
 :: ----------------------------------------------------------------------------
+:: Build Slicer
+:: ----------------------------------------------------------------------------
+::echo "Slicer 'Preview' release"
+call :fastdel "D:\D\P\S-0-build"
+"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicer_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicer_preview_nightly.txt
+
+:: ----------------------------------------------------------------------------
 :: Restore 'site-packages' directory associated with Slicer 'Stable' build
 :: ----------------------------------------------------------------------------
 call :fastdel "D:\D\S\S-0-build\python-install\Lib\site-packages"

--- a/overload.bat
+++ b/overload.bat
@@ -40,8 +40,8 @@ call :fastdel "D:\D\P\S-0-build"
 :: ----------------------------------------------------------------------------
 :: Restore 'site-packages' directory associated with Slicer 'Stable' build
 :: ----------------------------------------------------------------------------
-call :fastdel "D:\D\S\S-0-build\python-install\Lib\site-packages"
-robocopy D:\D\S\S-0-build\python-install\Lib\site-packages.bkp D:\D\S\S-0-build\python-install\Lib\site-packages /E
+::call :fastdel "D:\D\S\S-0-build\python-install\Lib\site-packages"
+::robocopy D:\D\S\S-0-build\python-install\Lib\site-packages.bkp D:\D\S\S-0-build\python-install\Lib\site-packages /E
 
 :: ----------------------------------------------------------------------------
 :: Build Slicer Extensions

--- a/overload.bat
+++ b/overload.bat
@@ -46,8 +46,8 @@ robocopy D:\D\S\S-0-build\python-install\Lib\site-packages.bkp D:\D\S\S-0-build\
 :: ----------------------------------------------------------------------------
 :: Build Slicer Extensions
 :: ----------------------------------------------------------------------------
-call :fastdel "D:\D\P\S-0-E-b"
-call :fastdel "D:\D\S\S-0-E-b"
+::call :fastdel "D:\D\P\S-0-E-b"
+::call :fastdel "D:\D\S\S-0-E-b"
 ::if "%IS_WEEKEND%"=="1" (
 ::  call :slicerextensions_stable_nightly
 ::  call :slicerextensions_preview_nightly


### PR DESCRIPTION
While the overload system cannot be reliably used for regular preview and nightly builds, we are re-enabling the build of Slicer to support local testing and development.

For more details, refer to https://discourse.slicer.org/t/windows-dashboard-extension-builds-interrupted-due-to-hardware-issue/35688

cc: @allemangD 