### PR TITLE
computron: Update CMAKE_OSX_DEPLOYMENT_TARGET to 13.0

### DIFF
--- a/computron-slicer_preview_nightly.cmake
+++ b/computron-slicer_preview_nightly.cmake
@@ -15,7 +15,7 @@ dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packa
 dashboard_set(GIT_TAG               "main")         # Specify a tag for Stable release
 
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "clang-14.0.6")    # Used only to set the build name

--- a/computron-slicerextensions_preview_nightly.cmake
+++ b/computron-slicerextensions_preview_nightly.cmake
@@ -13,7 +13,7 @@ dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "P")              # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "main")       # "main", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "clang-14.0.6")    # Used only to set the build name


### PR DESCRIPTION
This PR aims to update the CMAKE_OSX_DEPLOYMENT_TARGET for Slicer on macOS to be a version of macOS that is still supported by Apple.

This will support the following macOS versions:
- 15.x: Sequoia (2024)
- 14.x: Sonoma (2023)
- 13.x: Ventura (2022)

This is a follow-up to https://github.com/Slicer/DashboardScripts/pull/53 where the macOS deployment target was updated from 10.13 to 11.0. This PR updates the deployment target to macOS 13 (Ventura) now that macOS 15 (Sequoia) is out and Apple is no longer supporting macOS 12 (Monterey).

> [!NOTE] 
> The "computron" Slicer factory machine is running macOS 13.6.9 (Ventura) as seen in recent [build](https://slicer.cdash.org/builds/3553361).