### PR TITLE
metroplex: Remove obsolete ITK nightly used to build ITKPython

### DIFF
--- a/maintenance/metroplex/crontab
+++ b/maintenance/metroplex/crontab
@@ -10,7 +10,7 @@
 50 22 * * * (cd /home/kitware/Dashboards/Slicer/DashboardScripts && /usr/bin/git fetch origin && /usr/bin/git reset --hard origin/main > /home/kitware/Dashboards/Slicer/Logs/update-dashboardscripts.log 2>&1)
 
 # 23:00 EDT (4:00am UTC) every day
-0 23 * * * /home/kitware/Dashboards/Slicer/DashboardScripts/metroplex.sh --with-itk-dashboard > /home/kitware/Dashboards/Slicer/Logs/metroplex.log 2>&1
+0 23 * * * /home/kitware/Dashboards/Slicer/DashboardScripts/metroplex.sh > /home/kitware/Dashboards/Slicer/Logs/metroplex.log 2>&1
 
 # XXX Disable on 2018.03.30 by Jc: This script is now called from "Slicer/DashboardScripts/metroplex.sh"
 # 00:10 EDT (5:10am UTC) every day

--- a/metroplex.sh
+++ b/metroplex.sh
@@ -74,10 +74,6 @@ time /home/kitware/bin/slicer-buildenv-qt5-centos7-slicer-5.8 \
 # See https://github.com/Slicer/SlicerDockerUpdate
 time /bin/bash /home/kitware/Packaging/SlicerDockerUpdate/cronjob.sh >/home/kitware/Packaging/SlicerDockerUpdate/cronjob-log.txt 2>&1
 
-if [ $with_itk_dashboard == 1 ]; then
-  time /home/kitware/Dashboards/KWDashboardScripts/metroplex.sh > /home/kitware/Dashboards/Logs/metroplex.log 2>&1
-fi
-
 #-------------------------------------------------------------------------------
 # Download and patch the slicer-buildenv-qt5-centos7:slicer-4.11-2018.10.17 image
 SLICER_SALT_ENV_NAME=qt5-centos7


### PR DESCRIPTION
For reference, associated ctest script was the following:

```
$ cat path/to/metroplex_itk_python.cmake
cmake_minimum_required(VERSION 3.5)

set(CTEST_SITE                "metroplex.kitware")
set(CTEST_BUILD_NAME          "Linux-Python")
set(CTEST_BUILD_CONFIGURATION "Release")
set(CTEST_BUILD_FLAGS         "")
set(CTEST_CMAKE_GENERATOR     "Unix Makefiles")
set(CTEST_TEST_ARGS            PARALLEL_LEVEL 12)
set(ENV{ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS} 8)
get_filename_component(CTEST_DASHBOARD_ROOT "${CMAKE_CURRENT_LIST_DIR}/../Tests" ABSOLUTE)

set(dashboard_model Nightly)
set(dashboard_source_name ITK)
set(dashboard_binary_name ITKPython-build)
set(dashboard_cache "
ITK_WRAP_PYTHON:BOOL=ON
")

include(${CTEST_SCRIPT_DIRECTORY}/common/itk_common.cmake)
```

and corresponding shell script:

```
cat path/to/metroplex.sh
echo "ITKPythonPackage" >&2
pushd /path/to/Packaging/ITKPythonPackage
git reset --hard HEAD
git checkout master
git pull
rm dist/*
/path/to/Support/skbuild-venv/bin/python setup.py sdist --formats=gztar,zip
time scripts/dockcross-manylinux-build-wheels.sh > ../Logs/itk_python.log 2>&1
popd
source /path/to/Packaging/ITKPythonPackage/scripts/dockcross-manylinux-build-tarball.sh

pushd /path/to/Dashboards
time /path/to/Support/cmake-3.10.2-Linux-x86_64/bin/ctest -S KWDashboardScripts/metroplex_itk_python.cmake -V > Logs/itk_python.log 2>&1
popd
```