### PR TITLE
overload: Update CMake from 3.22.1 to 3.31.8

### DIFF
--- a/overload.bat
+++ b/overload.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 
-:: CMAKE_VERSION=3.22.1 - This comment is used by the maintenance script to look up the cmake version
+:: CMAKE_VERSION=3.31.8 - This comment is used by the maintenance script to look up the cmake version
 
 :: To facilitate execution of the command below by copy/paste, they do not include variables.
 
@@ -35,7 +35,7 @@ call :fastdel "C:\Users\svc-dashboard\AppData\Roaming\slicer.org"
 :: ----------------------------------------------------------------------------
 ::echo "Slicer 'Preview' release"
 call :fastdel "D:\D\P\S-0-build"
-"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicer_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicer_preview_nightly.txt
+"C:\cmake-3.31.8\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicer_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicer_preview_nightly.txt
 
 :: ----------------------------------------------------------------------------
 :: Restore 'site-packages' directory associated with Slicer 'Stable' build
@@ -63,13 +63,13 @@ call :fastdel "D:\D\P\S-0-build"
 :: ----------------------------------------------------------------------------
 :slicerextensions_preview_nightly
 ::echo "Slicer 'Preview' release extensions"
-"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicerextensions_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicerextensions_preview_nightly.txt
+"C:\cmake-3.31.8\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicerextensions_preview_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2022-slicerextensions_preview_nightly.txt
 EXIT /B 0
 
 :: ----------------------------------------------------------------------------
 :slicerextensions_stable_nightly
 ::echo "Slicer 'Stable' release extensions"
-"C:\cmake-3.22.1\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicerextensions_stable_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_stable_nightly.txt
+"C:\cmake-3.31.8\bin\ctest.exe" -S "D:\D\DashboardScripts\overload-vs2022-slicerextensions_stable_nightly.cmake" -C Release -VV -O D:\D\Logs\overload-vs2019-slicerextensions_stable_nightly.txt
 EXIT /B 0
 
 :: ----------------------------------------------------------------------------


### PR DESCRIPTION
This is done anticipating the use of `-- /p:CL_MPCount=N` supported starting with CMake 3.26.x.

See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7926