### PR TITLE
metroplex: Update compiler string to reflect updated build environment

### DIFF
--- a/metroplex-slicer_preview_nightly.cmake
+++ b/metroplex-slicer_preview_nightly.cmake
@@ -18,7 +18,7 @@ if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Ninja")
-dashboard_set(COMPILER              "g++-7.3.1")      # Used only to set the build name
+dashboard_set(COMPILER              "g++-14.2.1")      # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "")               # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")

--- a/metroplex-slicerextensions_preview_nightly.cmake
+++ b/metroplex-slicerextensions_preview_nightly.cmake
@@ -16,7 +16,7 @@ if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-dashboard_set(COMPILER              "g++-7.3.1")      # Used only to set the build name
+dashboard_set(COMPILER              "g++-14.2.1")      # Used only to set the build name
 dashboard_set(CTEST_BUILD_FLAGS     "-j5 -l4")        # Use multiple CPU cores to build. For example "-j -l4" on unix
 # By default, CMake auto-discovers the compilers
 #dashboard_set(CMAKE_C_COMPILER      "/path/to/c/compiler")


### PR DESCRIPTION
As of July 22nd the Linux build environment was updated where the GCC version changed from version 7 to 14. See https://discourse.slicer.org/t/slicer-build-environment-upgraded-to-qt5-almalinux8-gcc14/43802

This is to more accurately reflect the compiler that was used for the Slicer factory build when reviewing the builds over at https://slicer.cdash.org/index.php?project=SlicerPreview.