### PR TITLE
bluestreak: Update operating system string to Windows11

### DIFF
--- a/bluestreak-vs2022-slicer_preview_nightly.cmake
+++ b/bluestreak-vs2022-slicer_preview_nightly.cmake
@@ -8,7 +8,7 @@ endmacro()
 dashboard_set(DASHBOARDS_DIR        "C:/D/")
 dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
 dashboard_set(HOSTNAME              "bluestreak")
-dashboard_set(OPERATING_SYSTEM      "Windows10")
+dashboard_set(OPERATING_SYSTEM      "Windows11")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "P")              # (E)xperimental, (P)review or (S)table
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages

--- a/bluestreak-vs2022-slicer_stable_package.cmake
+++ b/bluestreak-vs2022-slicer_stable_package.cmake
@@ -8,7 +8,7 @@ endmacro()
 dashboard_set(DASHBOARDS_DIR        "C:/D/")
 dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
 dashboard_set(HOSTNAME              "bluestreak")
-dashboard_set(OPERATING_SYSTEM      "Windows10")
+dashboard_set(OPERATING_SYSTEM      "Windows11")
 dashboard_set(SCRIPT_MODE           "Experimental")   # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages

--- a/bluestreak-vs2022-slicerextensions_preview_nightly.cmake
+++ b/bluestreak-vs2022-slicerextensions_preview_nightly.cmake
@@ -8,7 +8,7 @@ endmacro()
 dashboard_set(DASHBOARDS_DIR        "C:/D")
 dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
 dashboard_set(HOSTNAME              "bluestreak")
-dashboard_set(OPERATING_SYSTEM      "Windows10")
+dashboard_set(OPERATING_SYSTEM      "Windows11")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "P")              # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "main")       # "main", X.Y, ...

--- a/bluestreak-vs2022-slicerextensions_stable_nightly.cmake
+++ b/bluestreak-vs2022-slicerextensions_stable_nightly.cmake
@@ -8,7 +8,7 @@ endmacro()
 dashboard_set(DASHBOARDS_DIR        "C:/D")
 dashboard_set(ORGANIZATION          "Kitware")        # One word, no ponctuation
 dashboard_set(HOSTNAME              "bluestreak")
-dashboard_set(OPERATING_SYSTEM      "Windows10")
+dashboard_set(OPERATING_SYSTEM      "Windows11")
 dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "5.8")          # "main", X.Y, ...


### PR DESCRIPTION
This reflects the migration that took place as described at https://discourse.slicer.org/t/maintenance-of-windows-dashboard-planned-for-august-26th/44210/4