### PR TITLE
metroplex: Remove obsolete workaround to fix image script

### DIFF
--- a/metroplex-slicersalt_stable_package.sh
+++ b/metroplex-slicersalt_stable_package.sh
@@ -21,8 +21,6 @@ fi
 
 # Update build environment
 $slicer_salt_script update
-# HACK: Workaround limitation of entrypoint.sh (see https://github.com/Slicer/SlicerBuildEnvironment/issues/16)
-sed -i ${slicer_salt_script} -e "s/slicer\/buildenv-${SLICER_SALT_ENV_NAME}:latest/slicer\/buildenv-${SLICER_SALT_ENV_NAME}:${SLICER_SALT_ENV_VERSION}/"
 
 # SlicerSALT dashboard settings
 slicersalt_docker_args="-e run_ctest_with_disable_clean=${run_slicersalt_ctest_with_disable_clean-FALSE}"

--- a/metroplex.sh
+++ b/metroplex.sh
@@ -21,8 +21,6 @@ fi
 
 # Update build environment
 $slicer_preview_script update
-# HACK: Workaround limitation of entrypoint.sh (see https://github.com/Slicer/SlicerBuildEnvironment/issues/16)
-sed -i ${slicer_preview_script} -e "s/slicer\/buildenv-${SLICER_PREVIEW_ENV_NAME}:latest/slicer\/buildenv-${SLICER_PREVIEW_ENV_NAME}:${SLICER_PREVIEW_ENV_VERSION}/"
 
 # Slicer dashboard settings
 docker_args="-e run_ctest_with_disable_clean=${run_ctest_with_disable_clean-FALSE}"
@@ -66,8 +64,6 @@ fi
 
 # Update build environment
 $slicer_salt_script update
-# HACK: Workaround limitation of entrypoint.sh (see https://github.com/Slicer/SlicerBuildEnvironment/issues/16)
-sed -i ${slicer_salt_script} -e "s/slicer\/buildenv-${SLICER_SALT_ENV_NAME}:latest/slicer\/buildenv-${SLICER_SALT_ENV_NAME}:${SLICER_SALT_ENV_VERSION}/"
 
 # SlicerSALT dashboard settings
 slicersalt_docker_args="-e run_ctest_with_disable_clean=${run_slicersalt_ctest_with_disable_clean-FALSE}"


### PR DESCRIPTION
This is was likely fixed in dockcross/dockcross@8f19ce7 ("Fix wrong file name in entrypoint dockcross -> dockcross.sh", 2021-08-04) itself integrated into dockbuild through dockbuild/dockbuild@9a17383 ("imagefiles 2022-01-03 (77775208)", 2022-01-03)

Related issues and pull requests:
* https://github.com/Slicer/SlicerBuildEnvironment/issues/16
* https://github.com/dockcross/dockcross/pull/536
* https://github.com/dockbuild/dockbuild/pull/78