### PR TITLE
computron: Update CMAKE_OSX_DEPLOYMENT_TARGET to 14.0 for preview builds

### DIFF
--- a/bluestreak-vs2022-slicer_preview_nightly.cmake
+++ b/bluestreak-vs2022-slicer_preview_nightly.cmake
@@ -15,7 +15,7 @@ dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packa
 dashboard_set(GIT_TAG               "main")         # Specify a tag for Stable release
 
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")

--- a/bluestreak-vs2022-slicer_stable_package.cmake
+++ b/bluestreak-vs2022-slicer_stable_package.cmake
@@ -15,7 +15,7 @@ dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packa
 dashboard_set(GIT_TAG               "v5.10.0")         # Specify a tag for Stable release
 set(CTEST_UPDATE_VERSION_ONLY 1)
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")

--- a/bluestreak-vs2022-slicerextensions_preview_nightly.cmake
+++ b/bluestreak-vs2022-slicerextensions_preview_nightly.cmake
@@ -13,7 +13,7 @@ dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "P")              # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "main")       # "main", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")

--- a/bluestreak-vs2022-slicerextensions_stable_nightly.cmake
+++ b/bluestreak-vs2022-slicerextensions_stable_nightly.cmake
@@ -13,7 +13,7 @@ dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "S")              # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "5.10")          # "main", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")

--- a/computron-slicer_preview_nightly.cmake
+++ b/computron-slicer_preview_nightly.cmake
@@ -15,7 +15,7 @@ dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packa
 dashboard_set(GIT_TAG               "main")         # Specify a tag for Stable release
 
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 # dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "")

--- a/computron-slicerextensions_preview_nightly.cmake
+++ b/computron-slicerextensions_preview_nightly.cmake
@@ -13,7 +13,7 @@ dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "P")              # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "main")       # "main", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "clang-17.0.0")    # Used only to set the build name

--- a/metroplex-slicer_preview_nightly.cmake
+++ b/metroplex-slicer_preview_nightly.cmake
@@ -15,7 +15,7 @@ dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packa
 dashboard_set(GIT_TAG               "main")         # Specify a tag for Stable release
 
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Ninja")
 # dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "")

--- a/metroplex-slicer_stable_package.cmake
+++ b/metroplex-slicer_stable_package.cmake
@@ -15,7 +15,7 @@ dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packa
 dashboard_set(GIT_TAG               "v5.10.0")         # Specify a tag for Stable release
 set(CTEST_UPDATE_VERSION_ONLY 1)
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Ninja")
 # dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "")

--- a/metroplex-slicerextensions_preview_nightly.cmake
+++ b/metroplex-slicerextensions_preview_nightly.cmake
@@ -13,7 +13,7 @@ dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "Preview")        # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "main")       # "main", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "g++-14.2.1")      # Used only to set the build name

--- a/metroplex-slicerextensions_stable_nightly.cmake
+++ b/metroplex-slicerextensions_stable_nightly.cmake
@@ -13,7 +13,7 @@ dashboard_set(SCRIPT_MODE           "Nightly")        # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "Stable")         # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "5.10")          # "main", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "g++-14.2.1")      # Used only to set the build name

--- a/metroplex-slicersalt_preview_nightly.cmake
+++ b/metroplex-slicersalt_preview_nightly.cmake
@@ -14,7 +14,7 @@ dashboard_set(Slicer_RELEASE_TYPE   "Preview")        # (E)xperimental, (P)revie
 # TODO: Re-enable packaging when automatic upload to Girder will be implemented
 dashboard_set(WITH_PACKAGES         FALSE)             # Enable to generate packages
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Ninja")
 dashboard_set(COMPILER              "g++-7.3.1")      # Used only to set the build name

--- a/metroplex-slicersalt_stable_package.cmake
+++ b/metroplex-slicersalt_stable_package.cmake
@@ -14,7 +14,7 @@ dashboard_set(Slicer_RELEASE_TYPE   "Stable")        # (E)xperimental, (P)review
 # TODO: Re-enable packaging when automatic upload to Girder will be implemented
 dashboard_set(WITH_PACKAGES         TRUE)             # Enable to generate packages
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Ninja")
 dashboard_set(COMPILER              "g++-7.3.1")      # Used only to set the build name


### PR DESCRIPTION
This PR aims to update the CMAKE_OSX_DEPLOYMENT_TARGET for Slicer on macOS to be a version of macOS that is still supported by Apple.

This will support the following macOS versions:
- 26.x Tahoe (2025)
- 15.x: Sequoia (2024)
- 14.x: Sonoma (2023)

This is a follow-up to https://github.com/Slicer/DashboardScripts/pull/73 and https://github.com/Slicer/DashboardScripts/commit/bd9d10a23c08becb7e7debff6b919df6a6d81143 where the macOS deployment target was updated from 11.0 to 13.0. This PR updates the deployment target to macOS 14 (Sonoma) now that macOS 26 (Tahoe) is out and Apple is no longer supporting macOS 13 (Ventura).

> [!NOTE] 
> The "computron" Slicer factory machine is running macOS 15.7.1 (Ventura) as seen in recent [discourse post](https://discourse.slicer.org/t/maintenance-of-macos-dashboard-in-progress-upgrading-from-ventura-to-sequoia/44950?u=jamesobutler).