### PR TITLE
bluestreak: Use %APPDATA% instead of hardcoded username

### DIFF
--- a/bluestreak-vs2022-slicer_stable_package.bat
+++ b/bluestreak-vs2022-slicer_stable_package.bat
@@ -5,7 +5,7 @@
 :: Clean Slicer settings
 :: ----------------------------------------------------------------------------
 :: See https://github.com/Slicer/Slicer/pull/6879 introduced in March 2023
-call :fastdel "C:\Users\svc-dashboard\AppData\Roaming\slicer.org"
+call :fastdel "%APPDATA%\slicer.org"
 
 :: ----------------------------------------------------------------------------
 :: Remove source and build directories

--- a/bluestreak.bat
+++ b/bluestreak.bat
@@ -28,7 +28,7 @@ echo IS_WEEKEND[%IS_WEEKEND%]
 :: Clean Slicer settings
 :: ----------------------------------------------------------------------------
 :: See https://github.com/Slicer/Slicer/pull/6879 introduced in March 2023
-call :fastdel "C:\Users\svc-dashboard\AppData\Roaming\slicer.org"
+call :fastdel "%APPDATA%\slicer.org"
 
 :: ----------------------------------------------------------------------------
 :: Build Slicer
@@ -59,7 +59,7 @@ if "%IS_WEEKEND%"=="1" (
 :: ----------------------------------------------------------------------------
 :: Clean SlicerSALT settings
 :: ----------------------------------------------------------------------------
-call :fastdel "C:\Users\svc-dashboard\AppData\Roaming\Kitware, Inc"
+call :fastdel "%APPDATA%\Kitware, Inc"
 
 :: force execution to quit at the end of the "main" logic
 EXIT /B %ERRORLEVEL%


### PR DESCRIPTION
Replace hardcoded C:\Users\svc-dashboard\AppData\Roaming paths with %APPDATA% so the scripts work regardless of which user runs the build.

This is to support the migration of the build user account from svc-dashboard to svc-bluestreak.

Past updates from weekly meetings:
- https://discourse.slicer.org/t/2026-01-20-weekly-meeting/45833/2#p-131373-windows-nightly-build-2
- https://discourse.slicer.org/t/2026-02-03-weekly-meeting/46044/3#p-131747-failing-windows-tests-4
- https://discourse.slicer.org/t/2026-02-10-weekly-meeting/46076#p-131881-windows-factory-machine-updates-ebrahim-1