### PR TITLE
Fix Windows stable build initial checkout and update maintenance docs from overload to bluestreak

### DIFF
--- a/bluestreak-vs2022-slicer_stable_package.bat
+++ b/bluestreak-vs2022-slicer_stable_package.bat
@@ -51,6 +51,7 @@ set empty_dir=%1-empty-%RANDOM%
 mkdir %empty_dir%
 robocopy %empty_dir% %1 /purge > nul
 rmdir /s/q %empty_dir%
+rmdir %1
 echo "Removing %1 - done [%time%]"
 :: Note:
 ::  * Using rm.exe (as suggested in link below) should be the fastest but it complains about path too long when deleting extension build directory.

--- a/bluestreak-vs2022-slicer_stable_package.cmake
+++ b/bluestreak-vs2022-slicer_stable_package.cmake
@@ -17,6 +17,8 @@ set(CTEST_UPDATE_VERSION_ONLY 1)
 if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
 endif()
+# Use 8.3 short path to avoid spaces in "Program Files" breaking ctest initial checkout
+set(CTEST_GIT_COMMAND "C:/PROGRA~1/Git/cmd/git.exe")
 dashboard_set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
 dashboard_set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
 dashboard_set(CTEST_CMAKE_GENERATOR_TOOLSET "v143")

--- a/bluestreak.bat
+++ b/bluestreak.bat
@@ -93,6 +93,7 @@ set empty_dir=%1-empty-%RANDOM%
 mkdir %empty_dir%
 robocopy %empty_dir% %1 /purge > nul
 rmdir /s/q %empty_dir%
+rmdir %1
 echo "Removing %1 - done [%time%]"
 :: Note:
 ::  * Using rm.exe (as suggested in link below) should be the fastest but it complains about path too long when deleting extension build directory.

--- a/maintenance/Makefile
+++ b/maintenance/Makefile
@@ -1,6 +1,6 @@
 
 UNIX_DASHBOARDS = computron metroplex
-WIN_DASHBOARDS = overload
+WIN_DASHBOARDS = bluestreak
 
 DASHBOARDS = $(UNIX_DASHBOARDS) $(WIN_DASHBOARDS)
 

--- a/maintenance/guides/re-trigger-nightly-build.md
+++ b/maintenance/guides/re-trigger-nightly-build.md
@@ -23,7 +23,7 @@ On unix, identify the process id associated with the build job, and run `kill -s
 2. Execute the following statements:
 
 ```
-cd /d/D/P/S-0
+cd /c/D/P/S-0
 git fetch origin
 git reset --hard origin/main
 ```
@@ -61,7 +61,7 @@ git reset --hard origin/main
 
 ```
 # Explicitly remove previous extensions build directory
-rm -rf /d/D/P/S-0-E-b
+rm -rf /c/D/P/S-0-E-b
 ```
 
 2. Open `Command Prompt` and execute the following statements:
@@ -73,7 +73,7 @@ set run_ctest_with_update=FALSE
 echo %run_ctest_with_disable_clean%
 echo %run_ctest_with_update%
 
-D:\D\DashboardScripts\overload.bat
+C:\D\DashboardScripts\bluestreak.bat
 ```
 
 ### unix

--- a/maintenance/guides/rename-and-update-release-scripts.md
+++ b/maintenance/guides/rename-and-update-release-scripts.md
@@ -34,7 +34,7 @@ echo "  TO_DOT [$TO_DOT]   TO_DOT_XY [$TO_DOT_XY]   TO_XYZ [$TO_XYZ]   TO_XY [$T
 for script in \
     computron.sh \
     metroplex.sh \
-    overload.bat \
+    bluestreak.bat \
     $(find -name "*slicerextensions_stable_nightly.cmake" -not -path "./.git/*" -not -name ".git*") \
     $(find -not -path "./.git/*" -not -name ".git*" | grep $TO_XY) \
     $(find -name "*_stable_package.*" -not -path "./.git/*" -not -name ".git*") \
@@ -83,8 +83,8 @@ gedit \
   computron-slicerextensions_stable_nightly.cmake \
   metroplex-slicer_stable_package.cmake \
   metroplex-slicerextensions_stable_nightly.cmake \
-  overload-vs*-slicer_stable_package.cmake \
-  overload-vs*-slicerextensions_stable_nightly.cmake
+  bluestreak-vs2022-slicer_stable_package.cmake \
+  bluestreak-vs2022-slicerextensions_stable_nightly.cmake
 ```
 
 * `GIT_TAG` should be set to the tag corresponding to Slicer version <TO_DOT>

--- a/maintenance/guides/update-cmake-nightly-build.md
+++ b/maintenance/guides/update-cmake-nightly-build.md
@@ -35,7 +35,7 @@ CMAKE_VERSION=X.Y.Z make remote-install-cmake
 
 ### Windows
 
-1. Connect to [overload](../overload/REMOTE_IP) using VNC
+1. Connect to bluestreak using NoMachine
 
 2. Open a command line terminal as Administrator
 

--- a/maintenance/guides/update-girder-client.md
+++ b/maintenance/guides/update-girder-client.md
@@ -29,20 +29,18 @@ make remote-install-girder-client
 
 ### Window
 
-1. Connect to [overload](../overload/REMOTE_IP) using VNC
+1. Connect to bluestreak using NoMachine
 
 2. Open a command line terminal
 
 3. If needed, create the environment executing the following statements:
 
 ```
-D:
-C:\Python36-x64\Scripts\virtualenv.exe D:\Support\girder_client-venv
+C:\Python37-x64\Scripts\virtualenv.exe C:\D\Support\girder-client-venv
 ```
 
 4. Finally, execute the following statements:
 
 ```
-D:
-D:\Support\girder_client-venv\Scripts\pip install -U girder_client
+C:\D\Support\girder-client-venv\Scripts\pip install -U girder_client
 ```

--- a/maintenance/guides/update-slicerpackagemanager-client.md
+++ b/maintenance/guides/update-slicerpackagemanager-client.md
@@ -29,15 +29,15 @@ make remote-install-slicerpackagemanager-client
 
 ### Window
 
-1. Connect to [overload](../overload/REMOTE_IP) using VNC
+1. Connect to bluestreak using NoMachine
 
 2. Open `Git Bash`
 
 3. Execute the following statements:
 
 ```
-[[ ! -d /d/Support/slicer_package_manager ]] && cd /d/Support && git clone https://github.com/girder/slicer_package_manager
-cd /d/Support/slicer_package_manager
+[[ ! -d /c/D/Support/slicer_package_manager ]] && cd /c/D/Support && git clone https://github.com/girder/slicer_package_manager
+cd /c/D/Support/slicer_package_manager
 git fetch origin
 git reset --hard origin/main
 ```
@@ -47,14 +47,12 @@ git reset --hard origin/main
 5. If needed, create the environment executing the following statements:
 
 ```
-D:
-C:\Python36-x64\Scripts\virtualenv.exe D:\Support\slicer_package_manager-venv
+C:\Python37-x64\Scripts\virtualenv.exe C:\D\Support\slicer_package_manager-venv
 ```
 
 6. Finally, execute the following statements:
 
 ```
-D:
-D:\Support\slicer_package_manager-venv\Scripts\pip install -U girder_client
-D:\Support\slicer_package_manager-venv\Scripts\pip install -U D:\Support\slicer_package_manager\python_client
+C:\D\Support\slicer_package_manager-venv\Scripts\pip install -U girder_client
+C:\D\Support\slicer_package_manager-venv\Scripts\pip install -U C:\D\Support\slicer_package_manager\python_client
 ```


### PR DESCRIPTION
After deleting the stable build on bluestreak due to annoying file permission issues while switching to user svc-bluestreak, running `bluestreak-vs2022-slicer_stable_package.bat` was not working to create a fresh stable build. It turned to be due to the space in "Program Files" making the git clone command fail. It wasn't an issue for svc-dashboard because it always had `C:\D\S\S-0` available from a previous build and so that clone command was not getting triggered.

Now a fresh stable build seems to be running with this version of `bluestreak-vs2022-slicer_stable_package.bat`.

Had claude update stale references in the docs while I was at it.