### PR TITLE
Remove stale references to overload, replaced with bluestreak

### DIFF
--- a/maintenance/Makefile
+++ b/maintenance/Makefile
@@ -1,6 +1,9 @@
 
 UNIX_DASHBOARDS = computron metroplex
-WIN_DASHBOARDS = overload
+
+# Windows dashboards are included by local script-editing targets. Remote
+# maintenance targets below intentionally operate only on UNIX_DASHBOARDS.
+WIN_DASHBOARDS = bluestreak
 
 DASHBOARDS = $(UNIX_DASHBOARDS) $(WIN_DASHBOARDS)
 

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -28,8 +28,9 @@ maintenance
 ```
 
 **Gotcha**: Since remote execution of script is currently implemented only for Unix based
-dashboards, directory associated with Windows dashboard will instead contain step-by-step
-instructions. This may be improved in the future by using OpenSSH for windows:
+dashboards, Windows dashboard maintenance is still performed manually. The Windows dashboard
+currently uses the `bluestreak` scripts with `C:\D` as the dashboard root. This may be improved
+in the future by using OpenSSH for windows:
 * source: https://github.com/PowerShell/openssh-portable
 * wiki: https://github.com/PowerShell/Win32-OpenSSH/wiki/Project-Status
 * Microsoft blog posts:
@@ -41,4 +42,3 @@ instructions. This may be improved in the future by using OpenSSH for windows:
 * These scripts references machines hosted in the Kitware, Inc. internal network, they will
   **NOT** if used externally.
 * Your SSH public key **must** also be added to the `.ssh/authorized_keys` file of each dashboards.
-

--- a/maintenance/guides/re-trigger-nightly-build.md
+++ b/maintenance/guides/re-trigger-nightly-build.md
@@ -16,14 +16,14 @@ On unix, identify the process id associated with the build job, and run `kill -s
 
 ## Step 2: Update the local source checkout
 
-### windows
+### Windows
 
 1. Open `Git Bash`
 
 2. Execute the following statements:
 
 ```
-cd /d/D/P/S-0
+cd /c/D/P/S-0
 git fetch origin
 git reset --hard origin/main
 ```
@@ -55,13 +55,13 @@ git reset --hard origin/main
 
 ## Step 4: Re-trigger the build script
 
-### windows
+### Windows
 
 1. Open `Git Bash` and execute the following statements:
 
 ```
 # Explicitly remove previous extensions build directory
-rm -rf /d/D/P/S-0-E-b
+rm -rf /c/D/P/S-0-E-b
 ```
 
 2. Open `Command Prompt` and execute the following statements:
@@ -73,7 +73,7 @@ set run_ctest_with_update=FALSE
 echo %run_ctest_with_disable_clean%
 echo %run_ctest_with_update%
 
-D:\D\DashboardScripts\overload.bat
+C:\D\DashboardScripts\bluestreak.bat
 ```
 
 ### unix

--- a/maintenance/guides/rename-and-update-release-scripts.md
+++ b/maintenance/guides/rename-and-update-release-scripts.md
@@ -34,7 +34,7 @@ echo "  TO_DOT [$TO_DOT]   TO_DOT_XY [$TO_DOT_XY]   TO_XYZ [$TO_XYZ]   TO_XY [$T
 for script in \
     computron.sh \
     metroplex.sh \
-    overload.bat \
+    bluestreak.bat \
     $(find -name "*slicerextensions_stable_nightly.cmake" -not -path "./.git/*" -not -name ".git*") \
     $(find -not -path "./.git/*" -not -name ".git*" | grep $TO_XY) \
     $(find -name "*_stable_package.*" -not -path "./.git/*" -not -name ".git*") \
@@ -83,8 +83,8 @@ gedit \
   computron-slicerextensions_stable_nightly.cmake \
   metroplex-slicer_stable_package.cmake \
   metroplex-slicerextensions_stable_nightly.cmake \
-  overload-vs*-slicer_stable_package.cmake \
-  overload-vs*-slicerextensions_stable_nightly.cmake
+  bluestreak-vs2022-slicer_stable_package.cmake \
+  bluestreak-vs2022-slicerextensions_stable_nightly.cmake
 ```
 
 * `GIT_TAG` should be set to the tag corresponding to Slicer version <TO_DOT>

--- a/maintenance/guides/update-cmake-nightly-build.md
+++ b/maintenance/guides/update-cmake-nightly-build.md
@@ -35,7 +35,7 @@ CMAKE_VERSION=X.Y.Z make remote-install-cmake
 
 ### Windows
 
-1. Connect to [overload](../overload/REMOTE_IP) using VNC
+1. Connect to bluestreak using VNC
 
 2. Open a command line terminal as Administrator
 

--- a/maintenance/guides/update-girder-client.md
+++ b/maintenance/guides/update-girder-client.md
@@ -27,22 +27,22 @@ cd maintenance
 make remote-install-girder-client
 ```
 
-### Window
+### Windows
 
-1. Connect to [overload](../overload/REMOTE_IP) using VNC
+1. Connect to bluestreak using VNC
 
 2. Open a command line terminal
 
-3. If needed, create the environment executing the following statements:
+3. Confirm the existing environment is available:
 
 ```
-D:
-C:\Python36-x64\Scripts\virtualenv.exe D:\Support\girder_client-venv
+C:
+dir C:\D\Support\girder_client-venv\Scripts\pip.exe
 ```
 
 4. Finally, execute the following statements:
 
 ```
-D:
-D:\Support\girder_client-venv\Scripts\pip install -U girder_client
+C:
+C:\D\Support\girder_client-venv\Scripts\pip install -U girder_client
 ```

--- a/maintenance/guides/update-slicerpackagemanager-client.md
+++ b/maintenance/guides/update-slicerpackagemanager-client.md
@@ -27,34 +27,38 @@ cd maintenance
 make remote-install-slicerpackagemanager-client
 ```
 
-### Window
+### Windows
 
-1. Connect to [overload](../overload/REMOTE_IP) using VNC
+1. Connect to bluestreak using VNC
 
-2. Open `Git Bash`
+2. Open a command line terminal
 
-3. Execute the following statements:
-
-```
-[[ ! -d /d/Support/slicer_package_manager ]] && cd /d/Support && git clone https://github.com/girder/slicer_package_manager
-cd /d/Support/slicer_package_manager
-git fetch origin
-git reset --hard origin/main
-```
-
-4. Open a command line terminal
-
-5. If needed, create the environment executing the following statements:
+3. Confirm the existing environment is available:
 
 ```
-D:
-C:\Python36-x64\Scripts\virtualenv.exe D:\Support\slicer_package_manager-venv
+C:
+dir C:\D\Support\slicer_package_manager-venv\Scripts\pip.exe
 ```
 
-6. Finally, execute the following statements:
+4. Install one of the following versions.
+
+Latest published release from PyPI:
 
 ```
-D:
-D:\Support\slicer_package_manager-venv\Scripts\pip install -U girder_client
-D:\Support\slicer_package_manager-venv\Scripts\pip install -U D:\Support\slicer_package_manager\python_client
+C:
+C:\D\Support\slicer_package_manager-venv\Scripts\pip install -U slicer-package-manager-client
+```
+
+Latest merged `main` from GitHub:
+
+```
+C:
+C:\D\Support\slicer_package_manager-venv\Scripts\pip install -U --force-reinstall "git+https://github.com/girder/slicer_package_manager.git@main#subdirectory=python_client"
+```
+
+5. Verify the client is available:
+
+```
+C:
+C:\D\Support\slicer_package_manager-venv\Scripts\slicer_package_manager_client --help
 ```

--- a/maintenance/overload/REMOTE_HOSTNAME
+++ b/maintenance/overload/REMOTE_HOSTNAME
@@ -1,1 +1,0 @@
-overload

--- a/maintenance/overload/REMOTE_IP
+++ b/maintenance/overload/REMOTE_IP
@@ -1,1 +1,0 @@
-overload

--- a/maintenance/overload/REMOTE_USERNAME
+++ b/maintenance/overload/REMOTE_USERNAME
@@ -1,1 +1,0 @@
-dashboard


### PR DESCRIPTION
(Also added a bit more about installing slicer-package-manager-client from the main branch since I had to do that)